### PR TITLE
Feature: border around spotlight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 CMakeLists.txt.user*
 .vscode
-
+build
+build/*

--- a/preferencesdlg.cc
+++ b/preferencesdlg.cc
@@ -291,7 +291,7 @@ QGroupBox* PreferencesDialog::createBorderGroupBox(Settings* settings)
 
   const auto borderSizeSpinBox = new QSpinBox(this);
   borderSizeSpinBox->setMaximum(50);
-  borderSizeSpinBox->setMinimum(3);
+  borderSizeSpinBox->setMinimum(0);
   borderSizeSpinBox->setValue(settings->borderSize());
   auto bordersizeHBox = new QHBoxLayout;
   bordersizeHBox->addWidget(borderSizeSpinBox);

--- a/preferencesdlg.cc
+++ b/preferencesdlg.cc
@@ -46,6 +46,7 @@ PreferencesDialog::PreferencesDialog(Settings* settings, Spotlight* spotlight, Q
   mainHBox->addWidget(createSpotGroupBox(settings));
   const auto spotScreenVBox = new QVBoxLayout();
   spotScreenVBox->addWidget(createDotGroupBox(settings));
+  spotScreenVBox->addWidget(createBorderGroupBox(settings));
   spotScreenVBox->addWidget(createScreenGroupBox(settings));
   mainHBox->addLayout(spotScreenVBox);
 
@@ -278,6 +279,42 @@ QGroupBox* PreferencesDialog::createDotGroupBox(Settings* settings)
 
   dotGrid->setColumnStretch(1, 1);
   return dotGroup;
+}
+
+QGroupBox* PreferencesDialog::createBorderGroupBox(Settings* settings)
+{
+  const auto borderGroup = new QGroupBox(tr("Show Border"), this);
+  borderGroup->setCheckable(true);
+  borderGroup->setChecked(settings->showBorder());
+  connect(borderGroup, &QGroupBox::toggled, settings, &Settings::setShowBorder);
+  connect(settings, &Settings::showBorderChanged, borderGroup, &QGroupBox::setChecked);
+
+  const auto borderSizeSpinBox = new QSpinBox(this);
+  borderSizeSpinBox->setMaximum(50);
+  borderSizeSpinBox->setMinimum(3);
+  borderSizeSpinBox->setValue(settings->borderSize());
+  auto bordersizeHBox = new QHBoxLayout;
+  bordersizeHBox->addWidget(borderSizeSpinBox);
+  bordersizeHBox->addWidget(new QLabel(tr("% of spotsize")));
+  connect(borderSizeSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+          settings, &Settings::setBorderSize);
+  connect(settings, &Settings::borderSizeChanged, borderSizeSpinBox, &QSpinBox::setValue);
+
+  const auto borderGrid = new QGridLayout(borderGroup);
+  borderGrid->addWidget(new QLabel(tr("Border Size"), this), 0, 0);
+  borderGrid->addLayout(bordersizeHBox, 0, 1);
+
+  const auto borderColor = new ColorSelector(settings->borderColor(), this);
+  connect(borderColor, &ColorSelector::colorChanged, settings, &Settings::setBorderColor);
+  connect(settings, &Settings::borderColorChanged, borderColor, &ColorSelector::setColor);
+  borderGrid->addWidget(new QLabel(tr("Border Color"), this), 1, 0);
+  borderGrid->addWidget(borderColor, 1, 1);
+
+  borderGrid->addWidget(new QWidget(this), 100, 0);
+  borderGrid->setRowStretch(100, 100);
+
+  borderGrid->setColumnStretch(1, 1);
+  return borderGroup;
 }
 
 QGroupBox* PreferencesDialog::createScreenGroupBox(Settings* settings)

--- a/preferencesdlg.h
+++ b/preferencesdlg.h
@@ -34,6 +34,7 @@ private:
 
   QGroupBox* createSpotGroupBox(Settings* settings);
   QGroupBox* createDotGroupBox(Settings* settings);
+  QGroupBox* createBorderGroupBox(Settings* settings);
   QGroupBox* createScreenGroupBox(Settings* settings);
   QWidget* createConnectedStateWidget(Spotlight* spotlight);
 

--- a/projecteurapp.cc
+++ b/projecteurapp.cc
@@ -128,7 +128,7 @@ ProjecteurApplication::ProjecteurApplication(int &argc, char **argv)
   //  });
 
   // Handling of spotlight window when input from spotlight device is detected
-  connect(m_spotlight, &Spotlight::spotActiveChanged, [window, settings](bool active)
+  connect(m_spotlight, &Spotlight::spotActiveChanged, [window](bool active)
   {
     if (active)
     {

--- a/projecteurapp.cc
+++ b/projecteurapp.cc
@@ -139,11 +139,6 @@ ProjecteurApplication::ProjecteurApplication(int &argc, char **argv)
       window->setFlags(window->flags() & ~Qt::SplashScreen);
       window->setFlags(window->flags() | Qt::ToolTip);
 
-      // A hack to automatically update border changes
-      QObject *spotarea = window->findChild<QObject*>("spotarea");
-      spotarea->setProperty("visible", false);
-      spotarea->setProperty("visible", settings->showBorder());
-
       if (window->screen())
       {
         const auto screenGeometry = window->screen()->geometry();

--- a/projecteurapp.cc
+++ b/projecteurapp.cc
@@ -128,7 +128,7 @@ ProjecteurApplication::ProjecteurApplication(int &argc, char **argv)
   //  });
 
   // Handling of spotlight window when input from spotlight device is detected
-  connect(m_spotlight, &Spotlight::spotActiveChanged, [window](bool active)
+  connect(m_spotlight, &Spotlight::spotActiveChanged, [window, settings](bool active)
   {
     if (active)
     {
@@ -138,6 +138,11 @@ ProjecteurApplication::ProjecteurApplication(int &argc, char **argv)
       window->hide();
       window->setFlags(window->flags() & ~Qt::SplashScreen);
       window->setFlags(window->flags() | Qt::ToolTip);
+
+      // A hack to automatically update border changes
+      QObject *spotarea = window->findChild<QObject*>("spotarea");
+      spotarea->setProperty("visible", false);
+      spotarea->setProperty("visible", settings->showBorder());
 
       if (window->screen())
       {

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -46,23 +46,26 @@ Window {
 
         Loader {
             id: spotShapeLoader
+            anchors.centerIn: centerRect
             width: centerRect.width;  height: width
             sourceComponent: Qt.createComponent(Settings.spotShape)
         }
         Loader {
             id: spotShapeLoader2
+            objectName: "spotarea"
             anchors.centerIn: centerRect
             width: centerRect.width;  height: width
             sourceComponent: Qt.createComponent(Settings.spotShape)
-            visible: Settings.showSpot || Settings.showBorder
-            onLoaded: {
+            visible: Settings.showBorder
+            onVisibleChanged: {
                 spotShapeLoader2.item.color="transparent";
-                if (Settings.showBorder){
+                //if (Settings.showBorder){
                     spotShapeLoader2.item.opacity=Settings.shadeOpacity;
-                    spotShapeLoader2.item.border.width=Settings.borderSize/100*spotShapeLoader2.item.width;
+                    spotShapeLoader2.item.border.width=Settings.borderSize/100*spotShapeLoader2.width;
                     spotShapeLoader2.item.border.color=Settings.borderColor;
                     spotShapeLoader2.item.visible=true;
-                }
+                //}
+
             }
         }
 

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -60,7 +60,7 @@ Window {
             onVisibleChanged: {
                 spotShapeLoader2.item.color="transparent";
                 if (Settings.showBorder){
-                    spotShapeLoader2.item.opacity=Settings.shadeOpacity;
+                    spotShapeLoader2.item.opacity=1-Settings.shadeOpacity;
                     spotShapeLoader2.item.border.width=Settings.borderSize/100*spotShapeLoader2.width;
                     spotShapeLoader2.item.border.color=Settings.borderColor;
                     spotShapeLoader2.item.visible=true;

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -56,16 +56,15 @@ Window {
             anchors.centerIn: centerRect
             width: centerRect.width;  height: width
             sourceComponent: Qt.createComponent(Settings.spotShape)
-            visible: Settings.showBorder
+            visible: Settings.shoSpot || Settings.showBorder
             onVisibleChanged: {
                 spotShapeLoader2.item.color="transparent";
-                //if (Settings.showBorder){
+                if (Settings.showBorder){
                     spotShapeLoader2.item.opacity=Settings.shadeOpacity;
                     spotShapeLoader2.item.border.width=Settings.borderSize/100*spotShapeLoader2.width;
                     spotShapeLoader2.item.border.color=Settings.borderColor;
                     spotShapeLoader2.item.visible=true;
-                //}
-
+                }
             }
         }
 

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -49,6 +49,22 @@ Window {
             width: centerRect.width;  height: width
             sourceComponent: Qt.createComponent(Settings.spotShape)
         }
+        Loader {
+            id: spotShapeLoader2
+            anchors.centerIn: centerRect
+            width: centerRect.width;  height: width
+            sourceComponent: Qt.createComponent(Settings.spotShape)
+            visible: Settings.showSpot || Settings.showBorder
+            onLoaded: {
+                spotShapeLoader2.item.color="transparent";
+                if (Settings.showBorder){
+                    spotShapeLoader2.item.opacity=Settings.shadeOpacity;
+                    spotShapeLoader2.item.border.width=Settings.borderSize/100*spotShapeLoader2.item.width;
+                    spotShapeLoader2.item.border.color=Settings.borderColor;
+                    spotShapeLoader2.item.visible=true;
+                }
+            }
+        }
 
         OpacityMask {
             id: spot

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -51,21 +51,20 @@ Window {
             sourceComponent: Qt.createComponent(Settings.spotShape)
         }
         Loader {
-            id: spotShapeLoader2
-            objectName: "spotarea"
+            id: borderShapeLoader
             anchors.centerIn: centerRect
             width: centerRect.width;  height: width
             sourceComponent: Qt.createComponent(Settings.spotShape)
-            visible: Settings.shoSpot || Settings.showBorder
-            onVisibleChanged: {
-                spotShapeLoader2.item.color="transparent";
-                if (Settings.showBorder){
-                    spotShapeLoader2.item.opacity=1-Settings.shadeOpacity;
-                    spotShapeLoader2.item.border.width=Settings.borderSize/100*spotShapeLoader2.width;
-                    spotShapeLoader2.item.border.color=Settings.borderColor;
-                    spotShapeLoader2.item.visible=true;
-                }
+
+            onSourceComponentChanged: {
+                if (!borderShapeLoader.item.border) return;
+                borderShapeLoader.item.visible = true;
+                borderShapeLoader.item.color = "transparent";
+                borderShapeLoader.item.opacity = Qt.binding(function() {return 1-Settings.shadeOpacity});
+                borderShapeLoader.item.border.width = Qt.binding(function() {return Settings.borderSize/100*borderShapeLoader.width});
+                borderShapeLoader.item.border.color = Qt.binding(function() {return Settings.borderColor});
             }
+            visible: Settings.showBorder
         }
 
         OpacityMask {

--- a/settings.cc
+++ b/settings.cc
@@ -20,6 +20,9 @@ namespace {
     constexpr char cursor[] = "cursor";
     constexpr char spotShape[] = "spotShape";
     constexpr char spotRotation[] ="spotRotation";
+    constexpr char showBorder[] = "showBorder";
+    constexpr char borderColor[] ="borderColor";
+    constexpr char borderSize[] = "borderSize";
 
     namespace defaultValue {
       constexpr bool showSpot = true;
@@ -33,6 +36,9 @@ namespace {
       constexpr Qt::CursorShape cursor = Qt::BlankCursor;
       constexpr char spotShape[] = "spotshapes/Circle.qml";
       constexpr double spotRotation = 0.0;
+      constexpr bool showBorder = false;
+      constexpr auto borderColor =Qt::red;
+      constexpr int borderSize = 3;
     }
   }
 }
@@ -72,6 +78,9 @@ void Settings::setDefaults()
   setCursor(settings::defaultValue::cursor);
   setSpotShape(settings::defaultValue::spotShape);
   setSpotRotation(settings::defaultValue::spotRotation);
+  setShowBorder(settings::defaultValue::showBorder);
+  setBorderColor(settings::defaultValue::borderColor);
+  setBorderSize(settings::defaultValue::borderSize);
   shapeSettingsSetDefaults();
 }
 
@@ -165,6 +174,9 @@ void Settings::load()
   setCursor(static_cast<Qt::CursorShape>(m_settings->value(::settings::cursor, static_cast<int>(settings::defaultValue::cursor)).toInt()));
   setSpotShape(m_settings->value(::settings::spotShape, settings::defaultValue::spotShape).toString());
   setSpotRotation(m_settings->value(::settings::spotRotation, settings::defaultValue::spotRotation).toDouble());
+  setShowBorder(m_settings->value(::settings::showBorder, settings::defaultValue::showBorder).toBool());
+  setBorderColor(m_settings->value(::settings::borderColor, QColor(settings::defaultValue::borderColor)).value<QColor>());
+  setBorderSize(m_settings->value(::settings::borderSize, settings::defaultValue::borderSize).toInt());
   shapeSettingsLoad();
 }
 
@@ -324,4 +336,34 @@ void Settings::setSpotRotationAllowed(bool allowed)
 
   m_spotRotationAllowed = allowed;
   emit spotRotationAllowedChanged(allowed);
+}
+
+void Settings::setShowBorder(bool show)
+{
+  if (show == m_showBorder)
+    return;
+
+  m_showBorder = show;
+  m_settings->setValue(::settings::showBorder, m_showBorder);
+  emit showBorderChanged(m_showBorder);
+}
+
+void Settings::setBorderColor(const QColor& color)
+{
+  if (color == m_borderColor)
+    return;
+
+  m_borderColor = color;
+  m_settings->setValue(::settings::borderColor, m_borderColor);
+  emit borderColorChanged(m_borderColor);
+}
+
+void Settings::setBorderSize(int size)
+{
+  if (size == m_borderSize)
+    return;
+
+  m_borderSize = qMin(qMax(3, size), 50);
+  m_settings->setValue(::settings::borderSize, m_borderSize);
+  emit borderSizeChanged(m_borderSize);
 }

--- a/settings.cc
+++ b/settings.cc
@@ -363,7 +363,7 @@ void Settings::setBorderSize(int size)
   if (size == m_borderSize)
     return;
 
-  m_borderSize = qMin(qMax(3, size), 50);
+  m_borderSize = qMin(qMax(0, size), 50);
   m_settings->setValue(::settings::borderSize, m_borderSize);
   emit borderSizeChanged(m_borderSize);
 }

--- a/settings.h
+++ b/settings.h
@@ -24,6 +24,9 @@ class Settings : public QObject
   Q_PROPERTY(double spotRotation READ spotRotation WRITE setSpotRotation NOTIFY spotRotationChanged)
   Q_PROPERTY(QObject* shapes READ shapeSettingsRootObject CONSTANT)
   Q_PROPERTY(bool spotRotationAllowed READ spotRotationAllowed NOTIFY spotRotationAllowedChanged)
+  Q_PROPERTY(bool showBorder READ showBorder WRITE setShowBorder NOTIFY showBorderChanged)
+  Q_PROPERTY(QColor borderColor READ borderColor WRITE setBorderColor NOTIFY borderColorChanged)
+  Q_PROPERTY(int borderSize READ borderSize WRITE setBorderSize NOTIFY borderSizeChanged)
 
 public:
   explicit Settings(QObject* parent = nullptr);
@@ -54,6 +57,12 @@ public:
   double spotRotation() const { return m_spotRotation; }
   void setSpotRotation(double rotation);
   bool spotRotationAllowed() const;
+  bool showBorder() const { return m_showBorder; }
+  void setShowBorder(bool show);
+  void setBorderColor(const QColor& color);
+  QColor borderColor() const { return m_borderColor; }
+  void setBorderSize(int size);
+  int borderSize() const { return m_borderSize; }
 
   class SpotShapeSetting {
   public:
@@ -113,6 +122,9 @@ signals:
   void spotShapeChanged(const QString& spotShapeQmlComponent);
   void spotRotationChanged(double rotation);
   void spotRotationAllowedChanged(bool allowed);
+  void showBorderChanged(bool show);
+  void borderColorChanged(const QColor& color);
+  void borderSizeChanged(int size);
 
 private:
   QSettings* m_settings = nullptr;
@@ -133,6 +145,9 @@ private:
   double m_spotRotation = 0.0;
   const QList<SpotShape> m_spotShapes;
   bool m_spotRotationAllowed = false;
+  bool m_showBorder=false;
+  QColor m_borderColor;
+  int m_borderSize = 3;
 
 private:
   void load();


### PR DESCRIPTION
A border is made around the spotlight, which may help in accentuating the content.

A border is further useful for implementing pointer and zoom mode as they have borders around them as per #14 .

The current implementation is limited in the sense it do not work with Custom QQuickItem element if they do not have border properties defined. 