### PR TITLE
Check if composite manager running on screen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,10 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 find_package(Qt5 COMPONENTS Core Gui Quick Widgets REQUIRED)
 
+if (UNIX)
+	find_package(Qt5 COMPONENTS X11Extras REQUIRED)
+endif (UNIX)
+
 add_executable(projecteur
   main.cc
   aboutdlg.cc           aboutdlg.h
@@ -43,6 +47,10 @@ add_executable(projecteur
 target_link_libraries(projecteur
   Qt5::Core Qt5::Quick Qt5::Widgets
 )
+
+if (UNIX)
+target_link_libraries(projecteur  Qt5::X11Extras)
+endif (UNIX)
 
 # Set version project properties for builds not from a git repository (e.g. created with git archive)
 # If creating the version number via git information fails, the following target properties

--- a/docker/Dockerfile.debian-stretch
+++ b/docker/Dockerfile.debian-stretch
@@ -12,5 +12,6 @@ RUN apt-get install -y --no-install-recommends \
 	git \
 	pkg-config \
 	udev \
-	qtdeclarative5-dev
+	qtdeclarative5-dev \
+	libqt5x11extras5-dev
 

--- a/docker/Dockerfile.ubuntu-16.04
+++ b/docker/Dockerfile.ubuntu-16.04
@@ -12,7 +12,8 @@ RUN apt-get install -y --no-install-recommends \
 	git \
 	pkg-config \
 	qtdeclarative5-dev \
-  wget
+	wget \
+	libqt5x11extras5-dev
 
 RUN cd /tmp && wget https://cmake.org/files/v3.14/cmake-3.14.4-Linux-x86_64.sh \
 	&& chmod +x cmake-3.14.4-Linux-x86_64.sh \

--- a/docker/Dockerfile.ubuntu-18.04
+++ b/docker/Dockerfile.ubuntu-18.04
@@ -12,5 +12,6 @@ RUN apt-get install -y --no-install-recommends \
 	udev \
 	git \
 	pkg-config \
-	qtdeclarative5-dev
+	qtdeclarative5-dev \
+	libqt5x11extras5-dev
 

--- a/docker/Dockerfile.ubuntu-18.10
+++ b/docker/Dockerfile.ubuntu-18.10
@@ -11,6 +11,7 @@ RUN apt-get install -y --no-install-recommends \
 	cmake \
 	git \
 	pkg-config \
-	qtdeclarative5-dev
+	qtdeclarative5-dev \
+	libqt5x11extras5-dev
 
 RUN apt-get install -y --no-install-recommends udev

--- a/docker/Dockerfile.ubuntu-19.04
+++ b/docker/Dockerfile.ubuntu-19.04
@@ -11,6 +11,7 @@ RUN apt-get install -y --no-install-recommends \
 	cmake \
 	git \
 	pkg-config \
-	qtdeclarative5-dev
+	qtdeclarative5-dev \
+	libqt5x11extras5-dev
 
 RUN apt-get install -y --no-install-recommends udev

--- a/settings.cc
+++ b/settings.cc
@@ -4,6 +4,11 @@
 #include <QCoreApplication>
 #include <QQmlPropertyMap>
 #include <QSettings>
+#include <QMessageBox>
+
+#ifdef Q_OS_UNIX
+    #include <QX11Info>
+#endif
 
 #include <QDebug>
 
@@ -240,6 +245,16 @@ void Settings::setShadeOpacity(double opacity)
 
 void Settings::setScreen(int screen)
 {
+	// Check for composite window manager running on screen if not inform user
+	// and forward them to troubleshooting section
+	// Please refer to issue 24 and 10.
+#ifdef Q_OS_UNIX
+    if (QX11Info::isPlatformX11() && !QX11Info::isCompositingManagerRunning(screen)){
+        QMessageBox msgBox;
+        char msg[] = "No Compositing Window Magager found running on the selected screen. It might result in improper functioning of SpotLight. \n\nPlease check troubleshooting guide.";
+        msgBox.warning(nullptr, tr("No compositer on screen"), tr(msg));
+    }
+#endif
   if (screen == m_screen)
     return;
 


### PR DESCRIPTION
If composite manager is not found running then user is informed and he is asked to take
      troubleshooting action as per issue #10 and #24 .

Add an extra dependency in form of `Qt5::X11Extras`.

The docker file for OpenSuse need update. As I do not run OpenSuse myself, so I did not know the package that provide `Qt5::X11Extras`.