### PR TITLE
Fix QString::null deprecated declarations

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -100,7 +100,7 @@ int main(int argc, char *argv[])
           }
           return QString("(%1)").arg(values.join(", "));
         }
-        return QString::null;
+        return QString();
       };
 
       Settings settings;

--- a/settings.cc
+++ b/settings.cc
@@ -544,5 +544,5 @@ QString Settings::StringProperty::typeToString(Type type)
   case Type::Integer: return "Integer";
   case Type::StringEnum: return "Value";
   }
-  return QString::null;
+  return QString();
 }


### PR DESCRIPTION
Fix deprecated declarations complain by the compiler
```
/dev/Projecteur/main.cc:103:25: warning: ‘QString::null’ is deprecated: use QString() [-Wdeprecated-declarations]
  103 |         return QString::null;
      |                         ^~~~
In file included from /usr/include/qt/QtCore/qcoreapplication.h:44,
                 from /usr/include/qt/QtWidgets/qapplication.h:44,
                 from /usr/include/qt/QtWidgets/QApplication:1,
                 from /home/louie/dev/Projecteur/projecteurapp.h:4,
                 from /home/louie/dev/Projecteur/main.cc:2:
/usr/include/qt/QtCore/qstring.h:818:23: note: declared here
  818 |     static const Null null;
      |                       ^~~~
```