### PR TITLE
Pointer mode (Zoom) changes on double click

### DIFF
--- a/55-spotlight.rules.in
+++ b/55-spotlight.rules.in
@@ -1,4 +1,4 @@
-# Set up permissions for non root users to open the Logitech Spotlight USB Receiver
+# Set up permissions for non root users to open the Logitech Spotlight Device and uinput
 # Enables the Projecteur application to access the device.
 
 # Copy this file to /lib/udev/rules.d/55-spotlight.rules
@@ -9,3 +9,8 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c53e", MODE="0660
 # Rule when connected via Bluetooth
 # Updated rule, thanks to Torsten Maehne (https://github.com/maehne)
 SUBSYSTEMS=="input", ATTRS{name}=="SPOTLIGHT*", MODE="0660", TAG+="uaccess"
+
+# Rules for uninput: Essential for creating a virtual input device that 
+# Projecteur use for forwarding SpotLight events to system after grabbing the 
+# Spotlight device
+KERNEL=="uinput", SUBSYSTEM=="misc", TAG+="uaccess", OPTIONS+="static_node=uinput"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ add_executable(projecteur
   src/settings.cc           src/settings.h
   src/spotlight.cc          src/spotlight.h
   src/spotshapes.cc         src/spotshapes.h
+  src/virtualdevice.h       src/virtualdevice.cc
   resources.qrc             qml/qml.qrc)
 
 target_link_libraries(projecteur
@@ -76,11 +77,18 @@ target_compile_definitions(projecteur PRIVATE
 #  VERSION_TYPE must be either 'release' or 'develop'
 set_target_properties(projecteur PROPERTIES 
   VERSION_MAJOR 0
-  VERSION_MINOR 6
+  VERSION_MINOR 7
   VERSION_PATCH 0
   VERSION_TYPE develop
 )
 add_version_info(projecteur "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# Create files containing generated version strings, helping package maintainers
+get_target_property(PROJECTEUR_VERSION_STRING projecteur VERSION_STRING)
+# Arch Linux = PKGBUILD/makepkg: '-' is not allowed in version number
+string(REPLACE "-" "" PROJECTEUR_VERSION_STRING_ARCHLINUX "${PROJECTEUR_VERSION_STRING}")
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/version-string" "${PROJECTEUR_VERSION_STRING}")
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/version-string.archlinux" "${PROJECTEUR_VERSION_STRING_ARCHLINUX}")
 
 # Translation
 list(APPEND languages de fr es)

--- a/src/projecteurapp.cc
+++ b/src/projecteurapp.cc
@@ -158,6 +158,13 @@ ProjecteurApplication::ProjecteurApplication(int &argc, char **argv, const Optio
       window->hide();
     }
   });
+  connect(m_spotlight, &Spotlight::spotModeChanged, [this]() {
+    m_settings->changeSpotMode();
+  });
+
+  connect(m_settings, &Settings::dblClickDurationChanged, [this](int duration) {
+    m_spotlight->dblClickDuration = duration;
+  });
 
   connect(window, &QWindow::visibleChanged, [this](bool v){
     if (!v && m_dialog->isVisible()) {

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -28,6 +28,7 @@ namespace {
     constexpr char borderOpacity[] = "borderOpacity";
     constexpr char zoomEnabled[] = "enableZoom";
     constexpr char zoomFactor[] = "zoomFactor";
+    constexpr char dblClickDuration[] = "dblClickDuration";
 
     namespace defaultValue {
       constexpr bool showSpotShade = true;
@@ -46,6 +47,7 @@ namespace {
       constexpr double borderOpacity = 0.8;
       constexpr bool zoomEnabled = false;
       constexpr double zoomFactor = 2.0;
+      constexpr int dblClickDuration = 300;
     }
 
     namespace ranges {
@@ -213,6 +215,7 @@ void Settings::setDefaults()
   setBorderOpacity(settings::defaultValue::borderOpacity);
   setZoomEnabled(settings::defaultValue::zoomEnabled);
   setZoomFactor(settings::defaultValue::zoomFactor);
+  setDblClickDuration(settings::defaultValue::dblClickDuration);
   shapeSettingsSetDefaults();
 }
 
@@ -311,6 +314,7 @@ void Settings::load()
   setBorderOpacity(m_settings->value(::settings::borderOpacity, settings::defaultValue::borderOpacity).toDouble());
   setZoomEnabled(m_settings->value(::settings::zoomEnabled, settings::defaultValue::zoomEnabled).toBool());
   setZoomFactor(m_settings->value(::settings::zoomFactor, settings::defaultValue::zoomFactor).toDouble());
+  setDblClickDuration(m_settings->value(::settings::dblClickDuration, settings::defaultValue::dblClickDuration).toInt());
   shapeSettingsLoad();
 }
 
@@ -532,6 +536,17 @@ void Settings::setZoomFactor(double factor)
   }
 }
 
+void Settings::setDblClickDuration(int duration)
+{
+  // duration in millisecond
+  if (m_dblClickDuration == duration)
+    return;
+
+  m_dblClickDuration = duration;
+  m_settings->setValue(::settings::dblClickDuration, m_dblClickDuration);
+  emit dblClickDurationChanged(m_dblClickDuration);
+}
+
 QString Settings::StringProperty::typeToString(Type type)
 {
   switch(type) {
@@ -542,4 +557,10 @@ QString Settings::StringProperty::typeToString(Type type)
   case Type::StringEnum: return "Value";
   }
   return QString();
+}
+
+void Settings::changeSpotMode()
+{
+  // Mode changing logic
+  setZoomEnabled(!zoomEnabled());
 }

--- a/src/settings.h
+++ b/src/settings.h
@@ -32,6 +32,7 @@ class Settings : public QObject
   Q_PROPERTY(double borderOpacity READ borderOpacity WRITE setBorderOpacity NOTIFY borderOpacityChanged)
   Q_PROPERTY(bool zoomEnabled READ zoomEnabled WRITE setZoomEnabled NOTIFY zoomEnabledChanged)
   Q_PROPERTY(double zoomFactor READ zoomFactor WRITE setZoomFactor NOTIFY zoomFactorChanged)
+  Q_PROPERTY(int dblClickDuration READ dblClickDuration WRITE setDblClickDuration NOTIFY dblClickDurationChanged)
 
 public:
   explicit Settings(QObject* parent = nullptr);
@@ -39,6 +40,7 @@ public:
   ~Settings() override;
 
   void setDefaults();
+  void changeSpotMode();
 
   bool showSpotShade() const { return m_showSpotShade; }
   void setShowSpotShade(bool show);
@@ -75,6 +77,8 @@ public:
   void setZoomEnabled(bool enabled);
   double zoomFactor() const { return m_zoomFactor; }
   void setZoomFactor(double factor);
+  int dblClickDuration() const { return m_dblClickDuration; }
+  void setDblClickDuration(int duration);
 
   template <typename T> struct SettingRange {
     const T min;
@@ -165,6 +169,7 @@ signals:
   void borderOpacityChanged(double opacity);
   void zoomEnabledChanged(bool enabled);
   void zoomFactorChanged(double zoomFactor);
+  void dblClickDurationChanged(int duration);
 
 private:
   QSettings* m_settings = nullptr;
@@ -190,6 +195,7 @@ private:
   double m_borderOpacity = 0.8;
   bool m_zoomEnabled = false;
   double m_zoomFactor = 2.0;
+  int m_dblClickDuration = 300;
 
   QList<QPair<QString, StringProperty>> m_stringPropertyMap;
 

--- a/src/spotlight.h
+++ b/src/spotlight.h
@@ -1,6 +1,11 @@
 // This file is part of Projecteur - https://github.com/jahnf/projecteur - See LICENSE.md and README.md
 #pragma once
 
+#include "virtualdevice.h"
+
+#include<iostream>
+#include<memory>
+
 #include <QObject>
 #include <map>
 
@@ -20,6 +25,7 @@ public:
   bool spotActive() const { return m_spotActive; }
   bool anySpotlightDeviceConnected() const;
   QStringList connectedDevices() const;
+  int dblClickDuration = 300;
 
 
   struct Device {
@@ -50,6 +56,7 @@ signals:
   void disconnected(const QString& devicePath); //!< signal for every device disconnected
   void anySpotlightDeviceConnectedChanged(bool connected);
   void spotActiveChanged(bool isActive);
+  void spotModeChanged();
 
 private:
   enum class ConnectionResult { CouldNotOpen, NotASpotlightDevice, Connected };
@@ -62,4 +69,8 @@ private:
   std::map<QString, QScopedPointer<QSocketNotifier>> m_eventNotifiers;
   QTimer* m_activeTimer;
   bool m_spotActive = false;
+  bool m_clicked = false;
+  bool m_spotDeviceGrabbed = false;
+  QTimer* m_clickTimer;
+  std::unique_ptr<VirtualDevice> m_virtualDevice;
 };

--- a/src/virtualdevice.cc
+++ b/src/virtualdevice.cc
@@ -1,0 +1,118 @@
+// This file is part of Projecteur - https://github.com/jahnf/projecteur - See LICENSE.md and README.md
+#include "virtualdevice.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <QDebug>
+
+class VirtualDevice;
+
+VirtualDevice::VirtualDevice() {
+  deviceStatus = setupVirtualDevice();
+}
+
+VirtualDevice::~VirtualDevice() {
+  if (isDeviceCreated()) {
+    ioctl(uinp_fd, UI_DEV_DESTROY);
+    close(uinp_fd);
+    qDebug("uinput Device Closed");
+  }
+}
+
+VirtualDevice::DeviceStatus VirtualDevice::getDeviceStatus(){
+  return deviceStatus;
+}
+
+// Setup uinput device that can send mouse and keyboard events. Logs the result too.
+VirtualDevice::DeviceStatus VirtualDevice::setupVirtualDevice() {
+  if (isDeviceCreated())
+    return DeviceStatus::Connected;
+
+  // Open the input device
+  if (access("/dev/uinput", F_OK) == -1) {
+    qDebug("File not found /dev/uinput");
+    return DeviceStatus::UinputNotFound;
+  }
+  uinp_fd = open("/dev/uinput", O_WRONLY | O_NDELAY);
+  if (uinp_fd < 0) {
+    qDebug("Unable to open /dev/uinput");
+    return DeviceStatus::UinputAccessDenied;
+  }
+
+  memset(&uinp,0,sizeof(uinp));
+  // Intialize the UINPUT device to NULL
+  strncpy(uinp.name, "Projecteur_input_device", UINPUT_MAX_NAME_SIZE);
+  uinp.id.bustype = BUS_USB;
+
+  // Setup the uinput device
+  ioctl(uinp_fd, UI_SET_EVBIT, EV_KEY);
+  ioctl(uinp_fd, UI_SET_EVBIT, EV_REL);
+  ioctl(uinp_fd, UI_SET_RELBIT, REL_X);
+  ioctl(uinp_fd, UI_SET_RELBIT, REL_Y);
+
+  for (int i=0; i < 256; i++) {
+    ioctl(uinp_fd, UI_SET_KEYBIT, i); }
+
+  ioctl(uinp_fd, UI_SET_KEYBIT, BTN_MOUSE);
+  ioctl(uinp_fd, UI_SET_KEYBIT, BTN_TOUCH);
+
+  ioctl(uinp_fd, UI_SET_KEYBIT, BTN_MOUSE);
+  ioctl(uinp_fd, UI_SET_KEYBIT, BTN_LEFT);
+  ioctl(uinp_fd, UI_SET_KEYBIT, BTN_MIDDLE);
+  ioctl(uinp_fd, UI_SET_KEYBIT, BTN_RIGHT);
+  ioctl(uinp_fd, UI_SET_KEYBIT, BTN_FORWARD);
+  ioctl(uinp_fd, UI_SET_KEYBIT, BTN_BACK);
+
+  // Create input device into input sub-system
+  write(uinp_fd, &uinp, sizeof(uinp));
+  if (ioctl(uinp_fd, UI_DEV_CREATE)) {
+    close(uinp_fd);
+    qDebug("Unable to create Virtual (UINPUT) device.");
+    return DeviceStatus::CouldNotCreate;
+  }
+
+  // Log the device name
+  char sysfs_device_name[16];
+  ioctl(uinp_fd, UI_GET_SYSNAME(sizeof(sysfs_device_name)), sysfs_device_name);
+  qDebug("uinput device: /sys/devices/virtual/input/%s", sysfs_device_name);
+
+  return DeviceStatus::Connected;
+}
+
+// Public methods to emit event from the device
+void VirtualDevice::emitEvent(u_int16_t type, u_int16_t code, int val) {
+  // If no virtual device is present then do not emit the event.
+  if (!isDeviceCreated())
+    return;
+
+  struct input_event ie;
+
+  ie.type = type;
+  ie.code = code;
+  ie.value = val;
+
+  emitEvent(ie, true);
+}
+
+void VirtualDevice::emitEvent(struct input_event ie, bool remove_timestamp) {
+  // If no virtual device is present then do not emit the event.
+  if (!isDeviceCreated())
+    return;
+
+  if (remove_timestamp) {
+    // timestamp values below are ignored
+    ie.time.tv_sec = 0;
+    ie.time.tv_usec = 0;
+  }
+
+  write(uinp_fd, &ie, sizeof(ie));
+}
+
+// Simulate mouse clicks
+void VirtualDevice::mouseLeftClick(){
+  emitEvent(EV_KEY, BTN_LEFT, 1);
+  emitEvent(EV_SYN, SYN_REPORT, 0);
+  emitEvent(EV_KEY, BTN_LEFT, 0);
+  emitEvent(EV_SYN, SYN_REPORT, 0);
+}

--- a/src/virtualdevice.h
+++ b/src/virtualdevice.h
@@ -1,0 +1,31 @@
+// This file is part of Projecteur - https://github.com/jahnf/projecteur - See LICENSE.md and README.md
+
+// Virtal Device to emit customized events from Projecteur device
+// The spotlight.cc grabs mouse inputs from Logitech Spotlight device.
+// This module is used when the input events are supposed to be forwarded to the system.
+
+# pragma once
+
+#include <linux/uinput.h>
+
+// Device that can act as virtual keyboard and mouse
+class VirtualDevice{
+  public:
+    VirtualDevice();
+    ~VirtualDevice();
+
+    enum class DeviceStatus { UinputNotFound, UinputAccessDenied, CouldNotCreate, Connected };
+    DeviceStatus getDeviceStatus();
+    bool isDeviceCreated(){ return (deviceStatus == DeviceStatus::Connected); }
+    void emitEvent(u_int16_t type, u_int16_t code, int val);
+    void emitEvent(struct input_event ie, bool remove_timestamp=false);
+    void mouseLeftClick();
+
+
+  private:
+    struct uinput_user_dev uinp;
+    int uinp_fd = -1;
+    DeviceStatus deviceStatus;
+
+    DeviceStatus setupVirtualDevice();
+};


### PR DESCRIPTION
The Zoom is toggled if user double tap the pointer (top most) button (within 300ms; can be changed as it is part of Setting).

A major redesign of events handling has occurred. As it was necessary that the double click (and associated two clicks) events should not be passed to presentation so projecteur now grabs the input from SpotLight device. However, all other events (except Mouse Click) is passed again to the system by using uinput interface. The current redesign can help in giving solution to #43 without using a custom bash script.

Double Click is not passed to system rather used for changing the mode of presenter (toggling Zoom Setting). This is same behaviour as official software.