### PR TITLE
Extend list of required Debian/Ubuntu packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ file in this repository: `55-projecteur.rules.in`
 * When building against the Qt version that comes with your distribution's packages
   you might need to install some  additional QML module packages. For example this
   is the case for Ubuntu, where you need to install the packages
-  `qml-module-qtgraphicaleffects`, `qml-module-qtquick-window2` and `qml-modules-qtquick2`
-  to satisfy the application's runtime dependencies.
+  `qml-module-qtgraphicaleffects`, `qml-module-qtquick-window2`, `qml-modules-qtquick2` and
+  `qtdeclarative5-dev` to satisfy the application's runtime dependencies.
 
 ### Application Menu
 


### PR DESCRIPTION
While trying to build the latest version from develop I realized that on Ubuntu 18.04 (and possibly on other Debian/Ubuntu versions too) one needs an additional package (`qtdeclarative5-dev`) installed to be able to successfully run CMake on the code.