### PR TITLE
X1mouse

### DIFF
--- a/devices.conf
+++ b/devices.conf
@@ -9,3 +9,4 @@
 0x2312, 0x863d, usb, August LP315
 0x2571, 0x4109, usb, AVATTO i10 Pro
 0x17ef, 0x60d9, usb, Lenovo ThinkPad X1 Presenter Mouse
+0x17ef, 0x60db, bt, Lenovo ThinkPad X1 Presenter Mouse

--- a/devices.conf
+++ b/devices.conf
@@ -8,3 +8,4 @@
 0x0c45, 0x8101, usb, AVATTO H100 / August WP200
 0x2312, 0x863d, usb, August LP315
 0x2571, 0x4109, usb, AVATTO i10 Pro
+0x17ef, 0x60d9, usb, Lenovo ThinkPad X1 Presenter Mouse


### PR DESCRIPTION
Adds the X1 Presenter Mouse as a supported device using USB or Bluetooth