### PR TITLE
Appstream file and manual page

### DIFF
--- a/cmake/templates/projecteur.1
+++ b/cmake/templates/projecteur.1
@@ -1,0 +1,55 @@
+.TH PROJECTEUR "1" "February 2020" "Projecteur 0.7" "User Commands"
+.SH NAME
+Projecteur \- virtual laser pointer for presentations
+.SH SYNOPSIS
+.B projecteur
+[\fI\,option\/\fR]
+.SH DESCRIPTION
+Projecteur provides a virtual laser pointer on the screen for use when giving
+presentations. The laser pointer can be controlled using a Logitech Spotlight
+or similar device. Projecteur supports a "laser pointer" like effect that is
+a colored dot on the screen, a "highlight" effect that dims the image except
+in the highlighted region, and a "zoom" effect that enlarges part of the
+display.
+.PP
+Projecteur can be configured with a dialog box activated from the system
+tray in a supported desktop environment.
+.PP
+.SH Options
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Show command line usage.
+.TP
+\fB\-\-help\-all\fR
+Show complete command line usage with all properties.
+.TP
+\fB\-v\fR, \fB\-\-version\fR
+Print application version.
+.TP
+\fB\-\-cfg\fR \fIFILE\fR
+Set custom config file.
+.TP
+\fB\-d\fR, \fB\-\-device\-scan\fR
+Print device\-scan results.
+.TP
+\fB\-l\fR, \fB\-\-log\-level\fR \fILEVEL\fR
+Set log level (dbg,inf,wrn,err).
+.TP
+\fB\-D\fR \fIDEVICE\fR
+Additional accepted device; DEVICE = vendorId:productId
+e.g., \fB\-D\fR 04b3:310c; e.g. \fB\-D\fR 0x0c45:0x8101
+.TP
+\fB\-c\fR \fICOMMAND\fR|\fIPROPERTY\fR
+Send command/property to a running instance. See \fBCommands\fP for
+details.
+.PP
+.SH Commands
+.TP
+spot=[on|off]
+Turn spotlight on/off.
+.TP
+settings=[show|hide]
+Show/hide preferences dialog.
+.TP
+quit
+Quit the running instance.

--- a/cmake/templates/projecteur.metainfo.xml
+++ b/cmake/templates/projecteur.metainfo.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component>
+    <id>projecteur</id>
+    <metadata_license>Expat</metadata_license>
+    <project_license>Expat</project_license>
+    <name>Projecteur</name>
+    <summary>Virtual pointer for the Logitech Spotlight device</summary>
+    <url type="homepage">https://github.com/jahnf/Projecteur/</url>
+    <description>
+        <p>
+            Projecteur is a virtual laser pointer for use with inertial
+            pointers such as the Logitech Spotlight. Projecteur can show
+            a colored dot, a highlighted circle or a zoom effect to act
+            as a pointer. The location of the pointer moves in response
+            to moving the handheld pointer device. The effect is much
+            like that of a traditional laser pointer, except that it is
+            captured by recording software and works across multiple screens.
+        </p>
+    </description>
+    <provides>
+        <modalias>usb:v046DpC53Ed*</modalias>
+    </provides>
+    <screenshots>
+        <screenshot type="default">
+            <caption>Highlight virtual pointer effect</caption>
+            <image type="source" width="867" height="775">https://raw.githubusercontent.com/jahnf/Projecteur/develop/doc/screenshot-spot.png</image>
+        </screenshot>
+    </screenshots>
+    <categories>
+        <category>AudioVideo</category>
+        <category>Audio</category>
+        <category>Midi</category>
+        <category>Sequencer</category>
+    </categories>
+</component>


### PR DESCRIPTION
This is a *draft* PR looking to add an appstream metainfo file and manual page to to Projecteur.

Both these files should probably live in `cmake/templates/` instead and have some level of templating done to them. They also need to be actually installed by CMake.

I'm happy to figure out more about Projecteur's CMake set up to look more at this at some stage, but also very happy for anyone else to do so!