### PR TITLE
Update cmake version in debian stretch container for correct package …

### DIFF
--- a/docker/Dockerfile.debian-stretch
+++ b/docker/Dockerfile.debian-stretch
@@ -23,3 +23,18 @@ RUN apt-get install -y --no-install-recommends \
 RUN apt-get install -y --no-install-recommends \
   libqt5x11extras5-dev \
   libusb-1.0-0-dev
+
+RUN apt-get install -y --no-install-recommends \
+  libqt5x11extras5-dev \
+  libusb-1.0-0-dev
+
+RUN apt-get install -y --no-install-recommends \
+  wget
+
+# Install newer CMake version,
+# otherwise the package version in the debian package
+# created by the dist-package target will not be correct
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.19.6/cmake-3.19.6-Linux-x86_64.sh && \
+  chmod +x cmake-3.19.6-Linux-x86_64.sh && \
+  ./cmake-3.19.6-Linux-x86_64.sh --skip-license --prefix=/usr && \
+  rm ./cmake-3.19.6-Linux-x86_64.sh


### PR DESCRIPTION
…version generation.

It seems that older CPack versions could not handle the RELEASE part of a package version (correctly).