### PR TITLE
Remove bintray download references

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -128,7 +128,6 @@ jobs:
         echo "upload_bin_pkg=${{ false }}" >> $GITHUB_ENV
         echo "upload_src_pkg=${{ false }}" >> $GITHUB_ENV
         echo "cloudsmith_upload_repo=projecteur-develop" >> $GITHUB_ENV
-        echo "bintray_upload_repo=projecteur-develop" >> $GITHUB_ENV
         echo "REPO_UPLOAD=${{ false }}" >> $GITHUB_ENV
 
     - name: Check for binary-pkg upload conditions
@@ -146,7 +145,6 @@ jobs:
     - if: env.BRANCH == 'master'
       run: |
         echo "cloudsmith_upload_repo=projecteur-stable" >> $GITHUB_ENV
-        echo "bintray_upload_repo=projecteur-master" >> $GITHUB_ENV
 
     # ===================================================================================
     # ---------- Upload artifacts to cloudsmith ----------
@@ -199,36 +197,3 @@ jobs:
         echo Uploading for ${DISTRO} - ${PKG_TYPE}: ${CLOUDSMITH_USER}/${CLOUDSMITH_REPO}/${DISTRO}
         cloudsmith push ${PKG_TYPE} -W -k ${CLOUDSMITH_API_KEY} --republish \
           ${CLOUDSMITH_USER}/${CLOUDSMITH_REPO}/${DISTRO} ${{ env.dist_pkg_artifact }}
-
-    # ===================================================================================
-    # ---------- Upload artifacts to bintray ----------
-    - name: Upload source-pkg to Bintray
-      if: env.upload_src_pkg == 'true'
-      uses: bpicode/github-action-upload-bintray@master
-      with:
-        file: ${{ env.src_pkg_artifact }}
-        api_user: jahnf
-        api_key: ${{ secrets.BINTRAY_API_KEY }}
-        repository_user: jahnf
-        repository: Projecteur
-        package: ${{ env.bintray_upload_repo }}
-        version: ${{ env.projecteur_version }}
-        upload_path: packages/branches/${{ env.BRANCH }}/${{ env.projecteur_version }}
-        calculate_metadata: false
-        publish: 1
-
-    - name: Upload binary package to Bintray
-      if: env.upload_bin_pkg == 'true'
-      uses: bpicode/github-action-upload-bintray@master
-      with:
-        file: ${{ env.dist_pkg_artifact }}
-        api_user: jahnf
-        api_key: ${{ secrets.BINTRAY_API_KEY }}
-        repository_user: jahnf
-        repository: Projecteur
-        package: ${{ env.bintray_upload_repo }}
-        version: ${{ env.projecteur_version }}
-        upload_path: packages/branches/${{ env.BRANCH }}/${{ env.projecteur_version }}
-        calculate_metadata: false
-        publish: 1
-

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ So here it is: a Linux application for the Logitech Spotlight.
 [<img src="doc/screenshot-settings.png" height="300" />](./doc/screenshot-settings.png)
 [<img src="doc/screenshot-spot.png" height="300" />](./doc/screenshot-spot.png)
 [<img src="doc/screenshot-button-mapping.png" height="300" />](./doc/screenshot-button-mapping.png)
-[<img src="doc/screenshot-traymenu.png">](./doc/screenshot-traymenu.png)
+[<img src="doc/screenshot-traymenu.png" />](./doc/screenshot-traymenu.png)
 
 ### Planned features
 
@@ -97,20 +97,21 @@ line option - button mapping will be disabled then.)
 
 ## Download
 
-The latest binary packages for some Linux distributions are available for download on bintray.
+The latest binary packages for some Linux distributions are available for download on cloudsmith.
 Currently binary packages for _Ubuntu_, _Debian_, _Fedora_, _OpenSuse_, _CentOS_ and
-_Arch_ Linux are automatically built.
+_Arch_ Linux are automatically built. For release version downloads see alse the project
+[github releases page](https://github.com/jahnf/Projecteur/releases).
 
-* Latest develop: [ ![Download][bintray-dev-img] ][dl-dev-bintray]
-* Latest release: [ ![Download][bintray-rel-img] ][dl-rel-bintray]
+* [**Latest release:** ![cloudsmith-rel-badge]][cloudsmith-rel-latest]
+* [Latest development version: ![cloudsmith-dev-badge]][cloudsmith-dev-latest]
 
-See also the [list of Linux repositories](./doc/LinuxRepositories.md) where _Projecteur_
+See also the **[list of Linux repositories](./doc/LinuxRepositories.md)** where _Projecteur_
 is available.
 
-[dl-dev-bintray]: https://bintray.com/jahnf/Projecteur/projecteur-develop/_latestVersion#files
-[dl-rel-bintray]: https://bintray.com/jahnf/Projecteur/projecteur-master/_latestVersion#files
-[bintray-dev-img]: https://api.bintray.com/packages/jahnf/Projecteur/projecteur-develop/images/download.svg
-[bintray-rel-img]: https://api.bintray.com/packages/jahnf/Projecteur/projecteur-master/images/download.svg
+[cloudsmith-rel-badge]: https://api-prd.cloudsmith.io/v1/badges/version/jahnf/projecteur-stable/raw/sources/latest/x/?render=true&badge_token=gAAAAABgPebvngKb3w0EsZUr_IHIIzlfYCipDOGxcJdzMRGI3BLdVsLf62Na7Cg6q11ps7yNgv3kR9KXyxJyjFFbPs2eTAGzvL-UXTonyqSY5D1fwva_o_g%3D
+[cloudsmith-rel-latest]: https://cloudsmith.io/~jahnf/repos/projecteur-stable/packages/?q=format%3Araw+tag%3Alatest
+[cloudsmith-dev-badge]: https://api-prd.cloudsmith.io/v1/badges/version/jahnf/projecteur-develop/raw/sources/latest/x/?render=true&badge_token=gAAAAABgPd_g3txb3xWrIHsaUrhBB7hOamTwfPVpR7xGUELEaQ0pGnxFnXO1cqTPAMDcTjRsHM2zAjx00OXU_5ARSQDofAUe6lIqKrKNykiMhVT_jlZAy-4%3D
+[cloudsmith-dev-latest]: https://cloudsmith.io/~jahnf/repos/projecteur-develop/packages/?q=format%3Araw+tag%3Alatest
 
 ## Building
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.9.1
+
+### Changes/Updates:
+
+- Fixes for automatically generated RPM Packages (especially Fedora)
+- Fixes for version numbers in generated packages (DEB and RPM)
+
 ## v0.9
 
 ### Changes/Updates:


### PR DESCRIPTION
Bintray will be shutting down in May. Removed automated uploads and references in the documentation.