### PR TITLE
Fixes high CPU after device-vibration

### DIFF
--- a/src/device-vibration.cc
+++ b/src/device-vibration.cc
@@ -407,7 +407,9 @@ void VibrationSettingsWidget::setIntensity(uint8_t intensity)
 // -------------------------------------------------------------------------------------------------
 void VibrationSettingsWidget::setSubDeviceConnection(SubDeviceConnection *sdc)
 {
-  m_subDeviceConnection = sdc;
+  if (sdc->type() == ConnectionType::Hidraw &&
+            sdc->mode() == ConnectionMode::ReadWrite)
+    m_subDeviceConnection = sdc;
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -427,8 +429,7 @@ void VibrationSettingsWidget::sendVibrateCommand()
   const uint8_t vint = m_sbIntensity->value();
   const uint8_t vibrateCmd[] = {0x10, 0x01, 0x09, 0x1a, vlen, 0xe8, vint};
 
-  const auto notifier = m_subDeviceConnection->socketNotifier();
-  const auto res = ::write(notifier->socket(), &vibrateCmd[0], sizeof(vibrateCmd));
+  const auto res = m_subDeviceConnection->sendData(vibrateCmd, sizeof(vibrateCmd));
   if (res != sizeof(vibrateCmd)) {
     logWarn(device) << "Could not write vibrate command to device socket.";
   }

--- a/src/device.cc
+++ b/src/device.cc
@@ -9,10 +9,10 @@
 
 #include <fcntl.h>
 #include <linux/hidraw.h>
-#include <linux/input.h>
 #include <unistd.h>
 
 LOGGING_CATEGORY(device, "device")
+LOGGING_CATEGORY(hid, "HID")
 
 namespace  {
   // -----------------------------------------------------------------------------------------------
@@ -72,17 +72,33 @@ SubDeviceConnection::~SubDeviceConnection() = default;
 
 // -------------------------------------------------------------------------------------------------
 bool SubDeviceConnection::isConnected() const {
-  return m_notifier && m_notifier->isEnabled();
+  if (type() == ConnectionType::Event)
+    return (m_readNotifier && m_readNotifier->isEnabled());
+  if (type() == ConnectionType::Hidraw)
+    return (m_readNotifier && m_readNotifier->isEnabled()) && (m_writeNotifier);
+  return false;
 }
 
 // -------------------------------------------------------------------------------------------------
 void SubDeviceConnection::disconnect() {
-  m_notifier.reset();
+  m_readNotifier.reset();
+  m_writeNotifier.reset();
 }
 
 // -------------------------------------------------------------------------------------------------
 void SubDeviceConnection::disable() {
-  if (m_notifier) m_notifier->setEnabled(false);
+  if (m_readNotifier) m_readNotifier->setEnabled(false);
+  if (m_writeNotifier) m_writeNotifier->setEnabled(false);
+}
+
+// -------------------------------------------------------------------------------------------------
+void SubDeviceConnection::disableWrite() {
+  if (m_writeNotifier) m_writeNotifier->setEnabled(false);
+}
+
+// -------------------------------------------------------------------------------------------------
+void SubDeviceConnection::enableWrite() {
+  if (m_writeNotifier) m_writeNotifier->setEnabled(true);
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -91,8 +107,13 @@ const std::shared_ptr<InputMapper>& SubDeviceConnection::inputMapper() const  {
 }
 
 // -------------------------------------------------------------------------------------------------
-QSocketNotifier* SubDeviceConnection::socketNotifier() {
-  return m_notifier.get();
+QSocketNotifier* SubDeviceConnection::socketReadNotifier() {
+  return m_readNotifier.get();
+}
+
+// -------------------------------------------------------------------------------------------------
+QSocketNotifier* SubDeviceConnection::socketWriteNotifier() {
+  return m_writeNotifier.get();
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -104,6 +125,11 @@ std::shared_ptr<SubEventConnection> SubEventConnection::create(const DeviceScan:
                                                                const DeviceConnection& dc)
 {
   const int evfd = ::open(sd.deviceFile.toLocal8Bit().constData(), O_RDONLY, 0);
+
+  if (evfd == -1) {
+    logWarn(device) << tr("Cannot open event device '%1' for read.").arg(sd.deviceFile);
+    return std::shared_ptr<SubEventConnection>();
+  }
 
   struct input_id id{};
   ioctl(evfd, EVIOCGID, &id); // get the event sub-device id
@@ -163,8 +189,8 @@ std::shared_ptr<SubEventConnection> SubEventConnection::create(const DeviceScan:
   }
 
   // Create socket notifier
-  connection->m_notifier = std::make_unique<QSocketNotifier>(evfd, QSocketNotifier::Read);
-  QSocketNotifier* const notifier = connection->m_notifier.get();
+  connection->m_readNotifier = std::make_unique<QSocketNotifier>(evfd, QSocketNotifier::Read);
+  QSocketNotifier* const notifier = connection->m_readNotifier.get();
   // Auto clean up and close descriptor on destruction of notifier
   connect(notifier, &QSocketNotifier::destroyed, [grabbed = connection->m_details.grabbed, notifier]() {
     if (grabbed) {
@@ -190,28 +216,28 @@ std::shared_ptr<SubHidrawConnection> SubHidrawConnection::create(const DeviceSca
   const int devfd = ::open(sd.deviceFile.toLocal8Bit().constData(), O_RDWR|O_NONBLOCK , 0);
 
   if (devfd == -1) {
-    logWarn(device) << tr("Could not open hidraw device '%1' for read/write.").arg(sd.deviceFile);
+    logWarn(device) << tr("Cannot open hidraw device '%1' for read/write.").arg(sd.deviceFile);
     return std::shared_ptr<SubHidrawConnection>();
   }
 
   int descriptorSize = 0;
   // Get Report Descriptor Size
   if (ioctl(devfd, HIDIOCGRDESCSIZE, &descriptorSize) < 0) {
-    logWarn(device) << tr("Could retrieve report descriptor size of hidraw device '%1'.").arg(sd.deviceFile);
+    logWarn(device) << tr("Cannot retrieve report descriptor size of hidraw device '%1'.").arg(sd.deviceFile);
     return std::shared_ptr<SubHidrawConnection>();
   }
 
   struct hidraw_report_descriptor reportDescriptor{};
   reportDescriptor.size = descriptorSize;
   if (ioctl(devfd, HIDIOCGRDESC, &reportDescriptor) < 0) {
-    logWarn(device) << tr("Could retrieve report descriptor size of hidraw device '%1'.").arg(sd.deviceFile);
+    logWarn(device) << tr("Cannot retrieve report descriptor of hidraw device '%1'.").arg(sd.deviceFile);
     return std::shared_ptr<SubHidrawConnection>();
   }
 
   struct hidraw_devinfo devinfo{};
   // get the hidraw sub-device id info
   if (ioctl(devfd, HIDIOCGRAWINFO, &devinfo) < 0) {
-    logWarn(device) << tr("Could get info from hidraw device '%1'.").arg(sd.deviceFile);
+    logWarn(device) << tr("Cannot get info from hidraw device '%1'.").arg(sd.deviceFile);
     return std::shared_ptr<SubHidrawConnection>();
   };
 
@@ -238,14 +264,51 @@ std::shared_ptr<SubHidrawConnection> SubHidrawConnection::create(const DeviceSca
     connection->m_details.deviceFlags |= DeviceFlag::Vibrate;
   }
 
-  // Create socket notifier
-  connection->m_notifier = std::make_unique<QSocketNotifier>(devfd, QSocketNotifier::Read);
-  QSocketNotifier* const notifier = connection->m_notifier.get();
+  // Create read and write socket notifiers
+  connection->m_readNotifier = std::make_unique<QSocketNotifier>(devfd, QSocketNotifier::Read);
+  QSocketNotifier* const readNotifier = connection->m_readNotifier.get();
   // Auto clean up and close descriptor on destruction of notifier
-  connect(notifier, &QSocketNotifier::destroyed, [notifier]() {
-    ::close(static_cast<int>(notifier->socket()));
+  connect(readNotifier, &QSocketNotifier::destroyed, [readNotifier]() {
+    ::close(static_cast<int>(readNotifier->socket()));
+  });
+
+  connection->m_writeNotifier = std::make_unique<QSocketNotifier>(devfd, QSocketNotifier::Write);
+  QSocketNotifier* const writeNotifier = connection->m_writeNotifier.get();
+  // Auto clean up and close descriptor on destruction of notifier
+  connect(writeNotifier, &QSocketNotifier::destroyed, [writeNotifier]() {
+    ::close(static_cast<int>(writeNotifier->socket()));
   });
 
   connection->m_details.phys = sd.phys;
+  connection->disableWrite(); // disable write notifier
   return connection;
+}
+
+// -------------------------------------------------------------------------------------------------
+ssize_t SubDeviceConnection::sendData(const QByteArray& hidppMsg)
+{
+  ssize_t res = -1;
+  bool isValidMsg = (hidppMsg.length() == 7 && hidppMsg.at(0) == 0x10);             // HID++ short message
+  isValidMsg = isValidMsg || (hidppMsg.length() == 20 && hidppMsg.at(0) == 0x11);   // HID++ long message
+
+  if (type() == ConnectionType::Hidraw && mode() == ConnectionMode::ReadWrite
+          && m_writeNotifier && isValidMsg)
+  {
+    enableWrite();
+    const auto notifier = socketWriteNotifier();
+    res = ::write(notifier->socket(), hidppMsg.data(), hidppMsg.length());
+    logDebug(hid) << "Write" << hidppMsg.toHex(':') << "to" << path();
+    disableWrite();
+  }
+
+  return res;
+}
+
+
+// -------------------------------------------------------------------------------------------------
+ssize_t SubDeviceConnection::sendData(const void* hidppMsg, size_t hidppMsgLen)
+{
+  const QByteArray hidppMsgArr(reinterpret_cast<const char*>(hidppMsg), hidppMsgLen);
+
+  return sendData(hidppMsgArr);
 }

--- a/src/device.h
+++ b/src/device.h
@@ -127,6 +127,11 @@ public:
   bool isConnected() const;
   void disconnect(); // destroys socket notifier and close file handle
   void disable(); // disable receiving/sending data
+  void disableWrite(); // disable sending data
+  void enableWrite(); // enable sending data
+
+  ssize_t sendData(const QByteArray& hidppMsg);                          // Send HID++ Message to HIDraw connection
+  ssize_t sendData(const void* hidppMsg, size_t hidppMsgLen); // Send HID++ Message to HIDraw connection
 
   auto type() const { return m_details.type; };
   auto mode() const { return m_details.mode; };
@@ -136,14 +141,16 @@ public:
   const auto& path() const { return m_details.devicePath; };
 
   const std::shared_ptr<InputMapper>& inputMapper() const;
-  QSocketNotifier* socketNotifier();
+  QSocketNotifier* socketReadNotifier();   // Read notifier for Hidraw and Event connections for receiving data from device
+  QSocketNotifier* socketWriteNotifier();  // Write notifier for Hidraw connection for sending data to device
 
 protected:
   SubDeviceConnection(const QString& path, ConnectionType type, ConnectionMode mode);
 
   SubDeviceConnectionDetails m_details;
   std::shared_ptr<InputMapper> m_inputMapper; // shared input mapper from parent device.
-  std::unique_ptr<QSocketNotifier> m_notifier;
+  std::unique_ptr<QSocketNotifier> m_readNotifier;
+  std::unique_ptr<QSocketNotifier> m_writeNotifier;   // only useful for Hidraw connections
 };
 
 // -------------------------------------------------------------------------------------------------

--- a/src/spotlight.cc
+++ b/src/spotlight.cc
@@ -13,10 +13,10 @@
 #include <fcntl.h>
 #include <sys/inotify.h>
 #include <sys/ioctl.h>
-#include <linux/input.h>
 #include <unistd.h>
 
 DECLARE_LOGGING_CATEGORY(device)
+DECLARE_LOGGING_CATEGORY(hid)
 
 namespace {
   const auto hexId = logging::hexId;
@@ -132,7 +132,8 @@ int Spotlight::connectDevices()
           auto devCon = SubEventConnection::create(scanSubDevice, *dc);
           if (addInputEventHandler(devCon)) return devCon;
         } else if (scanSubDevice.type == DeviceScan::SubDevice::Type::Hidraw) {
-          return SubHidrawConnection::create(scanSubDevice, *dc);
+          auto hidCon = SubHidrawConnection::create(scanSubDevice, *dc);
+          if(addHIDInputHandler(hidCon)) return hidCon;
         }
         return std::shared_ptr<SubDeviceConnection>();
       }();
@@ -289,16 +290,55 @@ void Spotlight::onEventDataAvailable(int fd, SubEventConnection& connection)
 }
 
 // -------------------------------------------------------------------------------------------------
+void Spotlight::onHIDDataAvailable(int fd, SubHidrawConnection& connection)
+{
+  QByteArray readVal(20, 0);
+  if (::read(fd, static_cast<void *>(readVal.data()), readVal.length()) < 0)
+  {
+    if (errno != EAGAIN)
+    {
+      const bool anyConnectedBefore = anySpotlightDeviceConnected();
+      connection.disable();
+      QTimer::singleShot(0, this, [this, devicePath=connection.path(), anyConnectedBefore](){
+        removeDeviceConnection(devicePath);
+        if (!anySpotlightDeviceConnected() && anyConnectedBefore) {
+          emit anySpotlightDeviceConnectedChanged(false);
+        }
+      });
+    }
+    return;
+  }
+  logDebug(hid) << "Received" << readVal.toHex(':') << "from" << connection.path();
+  // TODO: Process Logitech HIDPP message
+}
+
+// -------------------------------------------------------------------------------------------------
 bool Spotlight::addInputEventHandler(std::shared_ptr<SubEventConnection> connection)
 {
   if (!connection || connection->type() != ConnectionType::Event || !connection->isConnected()) {
     return false;
   }
 
-  QSocketNotifier* const notifier = connection->socketNotifier();
-  connect(notifier, &QSocketNotifier::activated, this,
+  QSocketNotifier* const readNotifier = connection->socketReadNotifier();
+  connect(readNotifier, &QSocketNotifier::activated, this,
   [this, connection=std::move(connection)](int fd) {
     onEventDataAvailable(fd, *connection.get());
+  });
+
+  return true;
+}
+
+// -------------------------------------------------------------------------------------------------
+bool Spotlight::addHIDInputHandler(std::shared_ptr<SubHidrawConnection> connection)
+{
+  if (!connection || connection->type() != ConnectionType::Hidraw || !connection->isConnected()) {
+    return false;
+  }
+
+  QSocketNotifier* const readNotifier = connection->socketReadNotifier();
+  connect(readNotifier, &QSocketNotifier::activated, this,
+  [this, connection=std::move(connection)](int fd) {
+    onHIDDataAvailable(fd, *connection.get());
   });
 
   return true;

--- a/src/spotlight.h
+++ b/src/spotlight.h
@@ -54,11 +54,13 @@ private:
   ConnectionResult connectSpotlightDevice(const QString& devicePath, bool verbose = false);
 
   bool addInputEventHandler(std::shared_ptr<SubEventConnection> connection);
+  bool addHIDInputHandler(std::shared_ptr<SubHidrawConnection> connection);
 
   bool setupDevEventInotify();
   int connectDevices();
   void removeDeviceConnection(const QString& devicePath);
   void onEventDataAvailable(int fd, SubEventConnection& connection);
+  void onHIDDataAvailable(int fd, SubHidrawConnection& connection);
 
   const Options m_options;
   std::map<DeviceId, std::shared_ptr<DeviceConnection>> m_deviceConnections;


### PR DESCRIPTION
This commit introduces separate read and write QSocketNotifier for
subdevices. Write notifier is required for sending data to HID
subdevice. Read notifier for HID subdevice will help in reading data
from device like battery percentage and configuring the spotlight device
like configuring it to send long press events for Next and previous
button (See #71 ).

This commit also fixes #133 as read notifier for HID subdevice do not
send activated signal continuosly after a write operation. Rather the
on activated signal, the device is read (However it currently does not
        do anything with the read value).

Fixes #133 