### PR TITLE
Enable Hidraw interface on spotlight bluetooth connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ So here it is: a Linux application for the Logitech Spotlight.
 * Button mapping:
   * Map any button on the device to (almost) any keyboard combination.
   * Switch between (cycle through) custom spotlight presets.
-* Vibration (Timer) Support for the Logitech Spotlight (USB)
+* Vibration (Timer) Support for the Logitech Spotlight
 * Usable without a presenter device (e.g. for online presentations)
 
 ### Screenshots

--- a/src/device-vibration.cc
+++ b/src/device-vibration.cc
@@ -20,8 +20,6 @@
 #include <chrono>
 #include <unistd.h>
 
-DECLARE_LOGGING_CATEGORY(device)
-
 // -------------------------------------------------------------------------------------------------
 namespace {
   constexpr int numTimers = 3;
@@ -423,12 +421,10 @@ void VibrationSettingsWidget::sendVibrateCommand()
   // Spotlight:
   //                                                    len         intensity
   // unsigned char vibrate[] = {0x10, 0x01, 0x09, 0x1a, 0x00, 0xe8, 0x80};
+
   const uint8_t vlen = m_sbLength->value();
   const uint8_t vint = m_sbIntensity->value();
-  const uint8_t vibrateCmd[] = {0x10, 0x01, 0x09, 0x1a, vlen, 0xe8, vint};
+  const uint8_t vibrateCmd[] = {0x10, 0x01, 0x09, 0x1d, vlen, 0xe8, vint};
 
-  const auto res = m_subDeviceConnection->sendData(vibrateCmd, sizeof(vibrateCmd));
-  if (res != sizeof(vibrateCmd)) {
-    logWarn(device) << "Could not write vibrate command to device socket.";
-  }
+  m_subDeviceConnection->sendData(vibrateCmd, sizeof(vibrateCmd));
 }

--- a/src/device.cc
+++ b/src/device.cc
@@ -6,6 +6,7 @@
 #include "logging.h"
 
 #include <QSocketNotifier>
+#include <QTimer>
 
 #include <fcntl.h>
 #include <linux/hidraw.h>
@@ -64,8 +65,8 @@ bool DeviceConnection::removeSubDevice(const QString& path)
 }
 
 // -------------------------------------------------------------------------------------------------
-SubDeviceConnection::SubDeviceConnection(const QString& path, ConnectionType type, ConnectionMode mode)
-  : m_details(path, type, mode) {}
+SubDeviceConnection::SubDeviceConnection(const QString& path, ConnectionType type, ConnectionMode mode, BusType busType)
+  : m_details(path, type, mode, busType) {}
 
 // -------------------------------------------------------------------------------------------------
 SubDeviceConnection::~SubDeviceConnection() = default;
@@ -118,7 +119,7 @@ QSocketNotifier* SubDeviceConnection::socketWriteNotifier() {
 
 // -------------------------------------------------------------------------------------------------
 SubEventConnection::SubEventConnection(Token, const QString& path)
-  : SubDeviceConnection(path, ConnectionType::Event, ConnectionMode::ReadOnly) {}
+  : SubDeviceConnection(path, ConnectionType::Event, ConnectionMode::ReadOnly, BusType::Unknown) {}
 
 // -------------------------------------------------------------------------------------------------
 std::shared_ptr<SubEventConnection> SubEventConnection::create(const DeviceScan::SubDevice& sd,
@@ -153,6 +154,7 @@ std::shared_ptr<SubEventConnection> SubEventConnection::create(const DeviceScan:
   }
 
   auto connection = std::make_shared<SubEventConnection>(Token{}, sd.deviceFile);
+  connection->m_details.busType = dc.deviceId().busType;
 
   if (!!(bitmask & (1 << EV_SYN))) connection->m_details.deviceFlags |= DeviceFlag::SynEvents;
   if (!!(bitmask & (1 << EV_REP))) connection->m_details.deviceFlags |= DeviceFlag::RepEvents;
@@ -207,7 +209,7 @@ std::shared_ptr<SubEventConnection> SubEventConnection::create(const DeviceScan:
 
 // -------------------------------------------------------------------------------------------------
 SubHidrawConnection::SubHidrawConnection(Token, const QString& path)
-  : SubDeviceConnection(path, ConnectionType::Hidraw, ConnectionMode::ReadWrite) {}
+  : SubDeviceConnection(path, ConnectionType::Hidraw, ConnectionMode::ReadWrite, BusType::Unknown) {}
 
 // -------------------------------------------------------------------------------------------------
 std::shared_ptr<SubHidrawConnection> SubHidrawConnection::create(const DeviceScan::SubDevice& sd,
@@ -252,15 +254,15 @@ std::shared_ptr<SubHidrawConnection> SubHidrawConnection::create(const DeviceSca
   }
 
   auto connection = std::make_shared<SubHidrawConnection>(Token{}, sd.deviceFile);
+  connection->m_details.busType = dc.deviceId().busType;
 
   fcntl(devfd, F_SETFL, fcntl(devfd, F_GETFL, 0) | O_NONBLOCK);
   if ((fcntl(devfd, F_GETFL, 0) & O_NONBLOCK) == O_NONBLOCK) {
     connection->m_details.deviceFlags |= DeviceFlag::NonBlocking;
   }
 
-  // For now vibration is only supported for the Logitech Spotlight (USB)
-  // TODO A more generic approach
-  if (dc.deviceId().vendorId == 0x46d && dc.deviceId().productId == 0xc53e) {
+  // For now vibration is only supported for the Logitech Spotlight (USB and Bluetooth)
+  if (dc.deviceId().vendorId == 0x46d && (dc.deviceId().productId == 0xc53e || dc.deviceId().productId == 0xb503)) {
     connection->m_details.deviceFlags |= DeviceFlag::Vibrate;
   }
 
@@ -281,33 +283,113 @@ std::shared_ptr<SubHidrawConnection> SubHidrawConnection::create(const DeviceSca
 
   connection->m_details.phys = sd.phys;
   connection->disableWrite(); // disable write notifier
+  connection->initSubDevice();
   return connection;
 }
 
 // -------------------------------------------------------------------------------------------------
-ssize_t SubDeviceConnection::sendData(const QByteArray& hidppMsg)
+void SubDeviceConnection::initSubDevice()
+{
+  int msgCount = 1, delay_ms = 20;
+
+  // Ping spotlight device for checking if is online
+  QTimer::singleShot(delay_ms*msgCount, this, [this](){pingSubDevice();});
+  msgCount++;
+
+  // Reset device: get rid of any device configuration by other programs -------
+  // Reset USB dongle
+  if (m_details.busType == BusType::Usb) {
+    QTimer::singleShot(delay_ms*msgCount, this, [this](){
+      const uint8_t data[] = {0x10, 0xff, 0x81, 0x00, 0x00, 0x00, 0x00};
+      sendData(data, sizeof(data), false);});
+    msgCount++;
+
+    // Turn off software bit and keep the wireless notification bit on
+    QTimer::singleShot(delay_ms*msgCount, this, [this](){
+      const uint8_t data[] = {0x10, 0xff, 0x80, 0x00, 0x00, 0x01, 0x00};
+      sendData(data, sizeof(data), false);});
+    msgCount++;
+  }
+
+  // Reset spotlight device
+  QTimer::singleShot(delay_ms*msgCount, this, [this](){
+    const uint8_t data[] = {0x10, 0x01, 0x05, 0x1d, 0x00, 0x00, 0x00};
+    sendData(data, sizeof(data), false);});
+  // Device Resetting complete -------------------------------------------------
+
+  // Add other configuration to enable features in device
+  // like enabling on Next and back button on hold functionality.
+  // No intialization needed for Event Sub device
+}
+
+// -------------------------------------------------------------------------------------------------
+void SubDeviceConnection::pingSubDevice()
+{
+  const uint8_t pingCmd[] = {0x10, 0x01, 0x00, 0x1d, 0x00, 0x00, 0x5d};
+  sendData(pingCmd, sizeof(pingCmd), false);
+}
+
+// -------------------------------------------------------------------------------------------------
+ssize_t SubDeviceConnection::sendData(const QByteArray& hidppMsg, bool checkDeviceOnline)
 {
   ssize_t res = -1;
-  bool isValidMsg = (hidppMsg.length() == 7 && hidppMsg.at(0) == 0x10);             // HID++ short message
-  isValidMsg = isValidMsg || (hidppMsg.length() == 20 && hidppMsg.at(0) == 0x11);   // HID++ long message
+
+  // If the message have 0xff as second byte, it is meant for USB dongle hence,
+  // should not be send when device is connected on bluetooth.
+  //
+  //
+  // Logitech Spotlight (USB) can receive data in two different length.
+  //   1. Short (10 byte long starting with 0x10)
+  //   2. Long (20 byte long starting with 0x11)
+  // However, bluetooth connection only accepts data in long (20 byte) packets.
+  // For converting standard short length data to long length data, change the first byte to 0x11 and
+  // pad the end of message with 0x00 to acheive the length of 20.
+
+  QByteArray _hidppMsg(hidppMsg);
+  if (m_details.busType == BusType::Bluetooth) {
+    if (static_cast<uint8_t>(hidppMsg.at(1)) == 0xff){
+      logDebug(hid) << "Invalid packet" << hidppMsg.toHex() << "for spotlight connected on bluetooth.";
+      return res;
+    }
+
+    if (hidppMsg.at(0) == 0x10) {
+      _hidppMsg.clear();
+      _hidppMsg.append(0x11);
+      _hidppMsg.append(hidppMsg.mid(1));
+      QByteArray padding(20 - _hidppMsg.length(), 0);
+      _hidppMsg.append(padding);
+    }
+  }
+
+  bool isValidMsg = (_hidppMsg.length() == 7 && _hidppMsg.at(0) == 0x10);             // HID++ short message
+  isValidMsg = isValidMsg || (_hidppMsg.length() == 20 && _hidppMsg.at(0) == 0x11);   // HID++ long message
+
+  // If checkDeviceOnline is true then do not send the packet if device is not online/active.
+  if (checkDeviceOnline && !isOnline()) {
+    logInfo(hid) << "The device is not active. Activate it by pressing any button on device.";
+    return res;
+  }
 
   if (type() == ConnectionType::Hidraw && mode() == ConnectionMode::ReadWrite
-          && m_writeNotifier && isValidMsg)
-  {
+          && m_writeNotifier && isValidMsg) {
     enableWrite();
     const auto notifier = socketWriteNotifier();
-    res = ::write(notifier->socket(), hidppMsg.data(), hidppMsg.length());
-    logDebug(hid) << "Write" << hidppMsg.toHex() << "to" << path();
+    res = ::write(notifier->socket(), _hidppMsg.data(), _hidppMsg.length());
     disableWrite();
+
+    if (res == _hidppMsg.length()) {
+      logDebug(hid) << "Write" << _hidppMsg.toHex() << "to" << path();
+    } else {
+      logWarn(hid) << "Writing to" << path() << "failed.";
+    }
   }
 
   return res;
 }
 
-
 // -------------------------------------------------------------------------------------------------
-ssize_t SubDeviceConnection::sendData(const void* hidppMsg, size_t hidppMsgLen)
+ssize_t SubDeviceConnection::sendData(const void* hidppMsg, size_t hidppMsgLen, bool checkDeviceOnline)
 {
   const QByteArray hidppMsgArr(reinterpret_cast<const char*>(hidppMsg), hidppMsgLen);
-  return sendData(hidppMsgArr);
+  return sendData(hidppMsgArr, checkDeviceOnline);
 }

--- a/src/devicescan.cc
+++ b/src/devicescan.cc
@@ -135,8 +135,8 @@ namespace {
             const auto busType = ids.size() ? ids[0].toUShort(nullptr, 16) : 0;
             switch (busType)
             {
-              case BUS_USB: spotlightDevice.busType = DeviceScan::Device::BusType::Usb; break;
-              case BUS_BLUETOOTH: spotlightDevice.busType = DeviceScan::Device::BusType::Bluetooth; break;
+              case BUS_USB: spotlightDevice.id.busType = BusType::Usb; break;
+              case BUS_BLUETOOTH: spotlightDevice.id.busType = BusType::Bluetooth; break;
             }
             spotlightDevice.id.vendorId = ids.size() > 1 ? ids[1].toUShort(nullptr, 16) : 0;
             spotlightDevice.id.productId = ids.size() > 2 ? ids[2].toUShort(nullptr, 16) : 0;
@@ -154,7 +154,6 @@ namespace {
     }
     return spotlightDevice;
   }
-
 }
 
 namespace DeviceScan {
@@ -257,10 +256,9 @@ namespace DeviceScan {
         }
       }
 
-      // For now: only check for hidraw sub-devices that have support for custom "proprietary"
-      // functionality/protocol with Projecteur built in.
-      // TODO check if _Projecteur_ supports additional "proprietary" device protocol features..
-      if (eventSubDeviceCount > 0) continue;
+      // Spotlight (Bluetooth) have hidraw interface in the same folder. However
+      // for other connection, it has separate folder for hidraw device and input device.
+      if (!(rootDevice.id.busType == BusType::Bluetooth) && eventSubDeviceCount > 0) continue;
 
       // Iterate over 'hidraw' sub-dircectory, check for hidraw device node
       const QFileInfo hidrawSubdir(QDir(hidIt.filePath()).filePath("hidraw"));

--- a/src/devicescan.h
+++ b/src/devicescan.h
@@ -31,12 +31,10 @@ namespace DeviceScan
   };
 
   struct Device { // Structure for device scan results
-    enum class BusType : uint16_t { Unknown, Usb, Bluetooth };
     const QString& getName() const { return userName.size() ? userName : name; }
     QString name;
     QString userName;
     DeviceId id;
-    BusType busType = BusType::Unknown;
     std::vector<SubDevice> subDevices;
   };
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -231,9 +231,9 @@ int main(int argc, char *argv[])
               << Main::tr(" * Found %1 supported devices. (%2 readable, %3 writable)")
                  .arg(result.devices.size()).arg(result.numDevicesReadable).arg(result.numDevicesWritable);
 
-      const auto busTypeToString = [](DeviceScan::Device::BusType type) -> QString {
-        if (type == DeviceScan::Device::BusType::Usb) return "USB";
-        if (type == DeviceScan::Device::BusType::Bluetooth) return "Bluetooth";
+      const auto busTypeToString = [](BusType type) -> QString {
+        if (type == BusType::Usb) return "USB";
+        if (type == BusType::Bluetooth) return "Bluetooth";
         return "unknown";
       };
 
@@ -266,7 +266,7 @@ int main(int argc, char *argv[])
         print() << "     " << "vendorId:  " << logging::hexId(device.id.vendorId);
         print() << "     " << "productId: " << logging::hexId(device.id.productId);
         print() << "     " << "phys:      " << device.id.phys;
-        print() << "     " << "busType:   " << busTypeToString(device.busType);
+        print() << "     " << "busType:   " << busTypeToString(device.id.busType);
         print() << "     " << "devices:   " << subDeviceList.join(", ");
         print() << "     " << "readable:  " << (allReadable ? "true" : "false");
         print() << "     " << "writable:  " << (allWriteable ? "true" : "false");

--- a/src/spotlight.cc
+++ b/src/spotlight.cc
@@ -308,8 +308,43 @@ void Spotlight::onHIDDataAvailable(int fd, SubHidrawConnection& connection)
     }
     return;
   }
+
+  // Only process HID++ packets (hence, the packets starting with 0x10 or 0x11)
+  if (!(readVal.at(0) == 0x10 || readVal.at(0) == 0x11)) {
+    return;
+  }
+
   logDebug(hid) << "Received" << readVal.toHex() << "from" << connection.path();
-  // TODO: Process Logitech HIDPP message
+
+  if (readVal.at(0) == 0x10)    // Logitech HIDPP SHORT message: 7 byte long
+  {
+    if (readVal.at(2) == 0x41 && !!(readVal.at(3) & 0x04 &&
+                                    !(readVal.at(4) & 1<<6))) {    // Logitech spotlight presenter unit got online and USB dongle acknowledged it.
+      // currently it is off as I observed that device send two online packet
+      // one with 0x10 and other with 0x11. Currently initsubDevice is triggered
+      // on 0x11 packet.
+      //connection.initSubDevice();
+    }
+  }
+
+  if (readVal.at(0) == 0x11)    // Logitech HIDPP LONG message: 20 byte long
+  {
+    if (readVal.at(2) == 0x00 && readVal.at(3) == 0x1d && readVal.at(6) == 0x5d) // response to ping
+    {
+      auto protocolVer = static_cast<uint8_t>(readVal.at(4)) + static_cast<uint8_t>(readVal.at(5))/10.0;
+      logDebug(hid) << connection.path() << "is online with protocol version" << protocolVer ;
+      connection.setHIDProtocol(protocolVer);
+    }
+    if (readVal.at(2) == 0x04 && readVal.at(4) ==0x01 &&
+            readVal.at(5) == 0x01 && readVal.at(6) == 0x01) {    // Logitech spotlight presenter unit got online.
+      connection.initSubDevice();
+    }
+    // TODO: Process other packets
+
+    if (readVal.at(2) == 0x09 && readVal.at(3) == 0x1d) {
+      logDebug(hid) << "Device acknowledged a vibration event.";
+    }
+  }
 }
 
 // -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This commit enables hidraw interface on logitech spotlight connected via
bluetooth. Three major changes are
1. DeviceId (in device.h) now include the information about the bus on
   which spotlight is connected (USB/Bluetooth).
2. sendData function (device.cc) for hidraw on bluetooth modifies the data
   before sending it. The bluetooth hid need the data in 20 byte long
   packages; smaller packet of 7 byte length is not allowed on bluetooth
   connection. More details for this conversion is provided in the
   function defintion as comment.
3. The projecteur now initialize HID device correctly (Get rid of any 
   device configuration by other programs). The projecteur also pings 
  the device and check the the HID++ version supported by the device.

With this code, device can vibrate (and support other functionality as 
being worked in #136 ) even if it is connected on bluetooth.

Note: To connect logitech spotlight using bluetooth, press top button
    and the last button till the led light starting flashing. The spotlight
    device can now be paired with computer.