### PR TITLE
Support for reading battery information from device

### DIFF
--- a/src/device-vibration.cc
+++ b/src/device-vibration.cc
@@ -20,8 +20,6 @@
 #include <chrono>
 #include <unistd.h>
 
-DECLARE_LOGGING_CATEGORY(device)
-
 // -------------------------------------------------------------------------------------------------
 namespace {
   constexpr int numTimers = 3;
@@ -423,12 +421,10 @@ void VibrationSettingsWidget::sendVibrateCommand()
   // Spotlight:
   //                                                    len         intensity
   // unsigned char vibrate[] = {0x10, 0x01, 0x09, 0x1a, 0x00, 0xe8, 0x80};
+
   const uint8_t vlen = m_sbLength->value();
   const uint8_t vint = m_sbIntensity->value();
   const uint8_t vibrateCmd[] = {0x10, 0x01, 0x09, 0x1a, vlen, 0xe8, vint};
 
-  const auto res = m_subDeviceConnection->sendData(vibrateCmd, sizeof(vibrateCmd));
-  if (res != sizeof(vibrateCmd)) {
-    logWarn(device) << "Could not write vibrate command to device socket.";
-  }
+  m_subDeviceConnection->sendData(vibrateCmd, sizeof(vibrateCmd));
 }

--- a/src/device-vibration.cc
+++ b/src/device-vibration.cc
@@ -419,12 +419,14 @@ void VibrationSettingsWidget::sendVibrateCommand()
   //      for not only the Spotlight device.
   //
   // Spotlight:
-  //                                                    len         intensity
+  //                                        present
+  //                                        controlID   len         intensity
   // unsigned char vibrate[] = {0x10, 0x01, 0x09, 0x1d, 0x00, 0xe8, 0x80};
 
   const uint8_t vlen = m_sbLength->value();
   const uint8_t vint = m_sbIntensity->value();
-  const uint8_t vibrateCmd[] = {0x10, 0x01, 0x09, 0x1d, vlen, 0xe8, vint};
+  const uint8_t pcID = m_subDeviceConnection->getFeatureSet()->getFeatureID(FeatureCode::PresenterControl);
+  const uint8_t vibrateCmd[] = {HIDPP_SHORT_MSG, MSG_TO_SPOTLIGHT, pcID, 0x1d, vlen, 0xe8, vint};
 
-  m_subDeviceConnection->sendData(vibrateCmd, sizeof(vibrateCmd));
+  if (pcID) m_subDeviceConnection->sendData(vibrateCmd, sizeof(vibrateCmd));
 }

--- a/src/device.cc
+++ b/src/device.cc
@@ -25,7 +25,9 @@ namespace  {
 // -------------------------------------------------------------------------------------------------
 DeviceConnection::DeviceConnection(const DeviceId& id, const QString& name,
                                    std::shared_ptr<VirtualDevice> vdev)
-  : m_deviceId(id), m_deviceName(name), m_inputMapper(std::make_shared<InputMapper>(std::move(vdev))){
+  : m_deviceId(id),
+    m_deviceName(name),
+    m_inputMapper(std::make_shared<InputMapper>(std::move(vdev))){
   m_featureSet = std::make_shared<FeatureSet>(FeatureSet());
 }
 
@@ -81,25 +83,18 @@ void DeviceConnection::queryBatteryStatus()
 // -------------------------------------------------------------------------------------------------
 void DeviceConnection::setBatteryInfo(const QByteArray& batteryData)
 {
-  bool test = m_featureSet->supportFeatureCode(FeatureCode::BatteryStatus);
-  if (test && batteryData.length() == 3)
+  if (m_featureSet->supportFeatureCode(FeatureCode::BatteryStatus) && batteryData.length() == 3)
   {
-    // battery percent is only meaningful when battery is discharging. However, save them anyway.
+    // Battery percent is only meaningful when battery is discharging. However, save them anyway.
     m_batteryInfo.currentLevel = static_cast<uint8_t>(batteryData.at(0) <= 100 ? batteryData.at(0): 100);
     m_batteryInfo.nextReportedLevel = static_cast<uint8_t>(batteryData.at(1) <= 100 ? batteryData.at(1): 100);
-    m_batteryInfo.status = static_cast<BatteryStatus>((batteryData.at(2) <= 0x06) ? batteryData.at(2): 0x06);
-  }
-  if (m_featureSet->supportFeatureCode(FeatureCode::BatteryVoltage)) {
-    //TODO: Implement battery code for this feature
-  }
-  if (m_featureSet->supportFeatureCode(FeatureCode::BatteryUnified)) {
-    //TODO: Implement battery code for this feature
+    m_batteryInfo.status = static_cast<BatteryStatus>((batteryData.at(2) <= 0x07) ? batteryData.at(2): 0x07);
   }
 }
 
 // -------------------------------------------------------------------------------------------------
-SubDeviceConnection::SubDeviceConnection(const QString& path, ConnectionType type, ConnectionMode mode, BusType busType)
-  : m_details(path, type, mode, busType) {}
+SubDeviceConnection::SubDeviceConnection(const QString& path, ConnectionType type, ConnectionMode mode)
+  : m_details(path, type, mode) {}
 
 // -------------------------------------------------------------------------------------------------
 SubDeviceConnection::~SubDeviceConnection() = default;
@@ -152,7 +147,7 @@ QSocketNotifier* SubDeviceConnection::socketWriteNotifier() {
 
 // -------------------------------------------------------------------------------------------------
 SubEventConnection::SubEventConnection(Token, const QString& path)
-  : SubDeviceConnection(path, ConnectionType::Event, ConnectionMode::ReadOnly, BusType::Unknown) {}
+  : SubDeviceConnection(path, ConnectionType::Event, ConnectionMode::ReadOnly) {}
 
 // -------------------------------------------------------------------------------------------------
 std::shared_ptr<SubEventConnection> SubEventConnection::create(const DeviceScan::SubDevice& sd,
@@ -187,7 +182,7 @@ std::shared_ptr<SubEventConnection> SubEventConnection::create(const DeviceScan:
   }
 
   auto connection = std::make_shared<SubEventConnection>(Token{}, sd.deviceFile);
-  connection->m_details.busType = dc.deviceId().busType;
+  connection->m_deviceID = dc.deviceId();
 
   if (!!(bitmask & (1 << EV_SYN))) connection->m_details.deviceFlags |= DeviceFlag::SynEvents;
   if (!!(bitmask & (1 << EV_REP))) connection->m_details.deviceFlags |= DeviceFlag::RepEvents;
@@ -242,7 +237,7 @@ std::shared_ptr<SubEventConnection> SubEventConnection::create(const DeviceScan:
 
 // -------------------------------------------------------------------------------------------------
 SubHidrawConnection::SubHidrawConnection(Token, const QString& path)
-  : SubDeviceConnection(path, ConnectionType::Hidraw, ConnectionMode::ReadWrite, BusType::Unknown) {}
+  : SubDeviceConnection(path, ConnectionType::Hidraw, ConnectionMode::ReadWrite) {}
 
 // -------------------------------------------------------------------------------------------------
 std::shared_ptr<SubHidrawConnection> SubHidrawConnection::create(const DeviceScan::SubDevice& sd,
@@ -287,34 +282,13 @@ std::shared_ptr<SubHidrawConnection> SubHidrawConnection::create(const DeviceSca
   }
 
   auto connection = std::make_shared<SubHidrawConnection>(Token{}, sd.deviceFile);
-  connection->m_details.busType = dc.deviceId().busType;
+  connection->m_deviceID = dc.deviceId();
+  connection->m_featureSet = dc.getFeatureSet();
+  connection->m_featureSet->setHIDDeviceFileDescriptor(devfd);
 
   fcntl(devfd, F_SETFL, fcntl(devfd, F_GETFL, 0) | O_NONBLOCK);
   if ((fcntl(devfd, F_GETFL, 0) & O_NONBLOCK) == O_NONBLOCK) {
     connection->m_details.deviceFlags |= DeviceFlag::NonBlocking;
-  }
-
-  // Read HID++ FeatureSet (Feature ID and Feature Code pairs) from device
-  if (dc.deviceId().vendorId == 0x46d) // Only check FeatureSet for Logitech devices
-  {
-    connection->m_featureSet = dc.getFeatureSet();
-    connection->m_featureSet->setHIDDeviceFileDescriptor(devfd);
-    connection->m_featureSet->populateFeatureTable();
-    if (connection->m_featureSet->getFeatureCount()) {
-      logDebug(hid) << "Loaded" << connection->m_featureSet->getFeatureCount() << "features for" << connection->path();
-      if (connection->m_featureSet->supportFeatureCode(FeatureCode::PresenterControl)) {
-        connection->m_details.deviceFlags |= DeviceFlag::Vibrate;
-        logDebug(hid) << "SubDevice" << connection->path() << "reported Vibration capabilities.";
-      }
-      if (connection->m_featureSet->supportFeatureCode(FeatureCode::BatteryStatus) ||
-              connection->m_featureSet->supportFeatureCode(FeatureCode::BatteryVoltage) ||
-              connection->m_featureSet->supportFeatureCode(FeatureCode::BatteryUnified)) {
-        connection->m_details.deviceFlags |= DeviceFlag::HasBattery;
-        logDebug(hid) << "SubDevice" << connection->path() << "can communicate battery information.";
-      }
-    } else {
-      logWarn(hid) << "Loading FeatureSet for" << connection->path() << "failed. Device might be inactive.";
-    }
   }
 
   // Create read and write socket notifiers
@@ -333,7 +307,6 @@ std::shared_ptr<SubHidrawConnection> SubHidrawConnection::create(const DeviceSca
   });
 
   connection->m_details.phys = sd.phys;
-  connection->disableWrite(); // disable write notifier
   connection->initSubDevice();
   return connection;
 }
@@ -341,7 +314,8 @@ std::shared_ptr<SubHidrawConnection> SubHidrawConnection::create(const DeviceSca
 // -------------------------------------------------------------------------------------------------
 void SubDeviceConnection::pingSubDevice()
 {
-  const uint8_t pingCmd[] = {0x10, 0x01, 0x00, 0x1d, 0x00, 0x00, 0x5d};
+  uint8_t rootID = 0x00;  // root ID is always 0x00 in any logitech device
+  const uint8_t pingCmd[] = {HIDPP_SHORT_MSG, MSG_TO_SPOTLIGHT, rootID, 0x1d, 0x00, 0x00, 0x5d};
   sendData(pingCmd, sizeof(pingCmd), false);
 }
 
@@ -359,57 +333,95 @@ void SubDeviceConnection::setHIDProtocol(float version) {
 void SubDeviceConnection::initSubDevice()
 {
   int msgCount = 0, delay_ms = 20;
+  if (type() == ConnectionType::Hidraw && mode() == ConnectionMode::ReadWrite)
+  {
+    if (m_deviceID.vendorId == 0x46d) // Only check FeatureSet for Logitech devices
+    {
+      // Reset device: get rid of any device configuration by other programs -------
+      if (m_deviceID.busType == BusType::Usb)
+      {
+        // Reset USB dongle
+        QTimer::singleShot(delay_ms*msgCount, this, [this](){
+          const uint8_t data[] = {HIDPP_SHORT_MSG, MSG_TO_USB_RECEIVER, HIDPP_SHORT_GET_FEATURE, 0x00, 0x00, 0x00, 0x00};
+          sendData(data, sizeof(data), false);});
+        msgCount++;
 
-  // Reset device: get rid of any device configuration by other programs -------
-  // Reset USB dongle
-  if (m_details.busType == BusType::Usb) {
-    QTimer::singleShot(delay_ms*msgCount, this, [this](){
-      const uint8_t data[] = {0x10, 0xff, 0x81, 0x00, 0x00, 0x00, 0x00};
-      sendData(data, sizeof(data), false);});
-    msgCount++;
+        // Turn off software bit and keep the wireless notification bit on
+        QTimer::singleShot(delay_ms*msgCount, this, [this](){
+          const uint8_t data[] = {HIDPP_SHORT_MSG, MSG_TO_USB_RECEIVER, HIDPP_SHORT_SET_FEATURE, 0x00, 0x00, 0x01, 0x00};
+          sendData(data, sizeof(data), false);});
+        msgCount++;
 
-    // Turn off software bit and keep the wireless notification bit on
-    QTimer::singleShot(delay_ms*msgCount, this, [this](){
-      const uint8_t data[] = {0x10, 0xff, 0x80, 0x00, 0x00, 0x01, 0x00};
-      sendData(data, sizeof(data), false);});
-    msgCount++;
+        // Initialize USB dongle
+        QTimer::singleShot(delay_ms*msgCount, this, [this](){
+          const uint8_t data[] = {HIDPP_SHORT_MSG, MSG_TO_USB_RECEIVER, HIDPP_SHORT_SET_FEATURE, 0x02, 0x02, 0x00, 0x00};
+          sendData(data, sizeof(data), false);});
+        msgCount++;
+
+        QTimer::singleShot(delay_ms*msgCount, this, [this](){
+          const uint8_t data[] = {HIDPP_SHORT_MSG, MSG_TO_USB_RECEIVER, HIDPP_SHORT_SET_FEATURE, 0x00, 0x00, 0x09, 0x00};
+          sendData(data, sizeof(data), false);});
+        msgCount++;
+      }
+
+      // Read HID++ FeatureSet (Feature ID and Feature Code pairs) from logitech device
+      disable();
+      if (m_featureSet->getFeatureCount() == 0) m_featureSet->populateFeatureTable();
+      if (m_featureSet->getFeatureCount()) {
+        logDebug(hid) << "Loaded" << m_featureSet->getFeatureCount() << "features for" << path();
+        if (m_featureSet->supportFeatureCode(FeatureCode::PresenterControl)) {
+          m_details.deviceFlags |= DeviceFlag::Vibrate;
+          logDebug(hid) << "SubDevice" << path() << "reported Vibration capabilities.";
+        }
+        if (m_featureSet->supportFeatureCode(FeatureCode::BatteryStatus)) {
+          m_details.deviceFlags |= DeviceFlag::ReportBattery;
+          logDebug(hid) << "SubDevice" << path() << "can communicate battery information.";
+        }
+      } else {
+        logWarn(hid) << "Loading FeatureSet for" << path() << "failed. Device might be inactive.";
+        logInfo(hid) << "Press any button on device to activate it.";
+      }
+      if (m_readNotifier) m_readNotifier->setEnabled(true);
+      disableWrite();
+
+      // Reset spotlight device
+      if (m_featureSet->getFeatureCount()) {
+        const auto resetID = m_featureSet->getFeatureID(FeatureCode::Reset);
+        if (resetID) {
+          QTimer::singleShot(delay_ms*msgCount, this, [this, resetID](){
+            const uint8_t data[] = {HIDPP_SHORT_MSG, MSG_TO_SPOTLIGHT, resetID, 0x1d, 0x00, 0x00, 0x00};
+            sendData(data, sizeof(data), false);});
+          msgCount++;
+        }
+      }
+      // Device Resetting complete -------------------------------------------------
+
+      if (m_deviceID.busType == BusType::Usb) {
+        // Ping spotlight device for checking if is online
+        // the response will have the version for HID++ protocol.
+        QTimer::singleShot(delay_ms*msgCount, this, [this](){pingSubDevice();});
+        msgCount++;
+      } else if (m_deviceID.busType == BusType::Bluetooth) {
+        // Bluetooth connection mean HID++ v2.0+.
+        // Setting version to 6.4: same as USB connection.
+        setHIDProtocol(6.4);
+      }
+      // Add other configuration to enable features in device
+      // like enabling on Next and back button on hold functionality.
+    }
   }
-
-  // Reset spotlight device
-  QTimer::singleShot(delay_ms*msgCount, this, [this](){
-    const uint8_t data[] = {0x10, 0x01, 0x05, 0x1d, 0x00, 0x00, 0x00};
-    sendData(data, sizeof(data), false);});
-  msgCount++;
-  // Device Resetting complete -------------------------------------------------
-
-  if (m_details.busType == BusType::Usb) {
-    // Ping spotlight device for checking if is online
-    // the response will have the version for HID++ protocol.
-    QTimer::singleShot(delay_ms*msgCount, this, [this](){pingSubDevice();});
-    msgCount++;
-  } else if (m_details.busType == BusType::Bluetooth) {
-    // Bluetooth connection mean HID++ v2.0+.
-    // Setting version to 6.4: same as USB connection.
-    setHIDProtocol(6.4);
-  }
-
-  // Add other configuration to enable features in device
-  // like enabling on Next and back button on hold functionality.
-  // No intialization needed for Event Sub device
+  // No initialization for Event SubDevice
 }
 
 // -------------------------------------------------------------------------------------------------
 void SubDeviceConnection::queryBatteryStatus()
 {
-  // if we make battery feature request packet by sending {0x11, 0x01, 0x00, 0x0d, 0x10, 0x00 ... padded by 0x00}
-  // batteryFeatureID is the fifth byte obtained by as device response.
-  // batteryFeatureID may differ for different logitech devices and may change after firmware update.
-  // last checked, batteryFeatureID was 0x06 for logitech spotlight.
-
-  if (!!(flags() & DeviceFlag::HasBattery)) {
-    const uint8_t batteryFeatureID = 0x06;
-    const uint8_t batteryCmd[] = {0x10, 0x01, batteryFeatureID, 0x0d, 0x00, 0x00, 0x00};
-    sendData(batteryCmd, sizeof(batteryCmd), false);
+  if (!!(flags() & DeviceFlag::ReportBattery)) {
+    const uint8_t batteryFeatureID = m_featureSet->getFeatureID(FeatureCode::BatteryStatus);
+    if (batteryFeatureID) {
+      const uint8_t batteryCmd[] = {HIDPP_SHORT_MSG, MSG_TO_SPOTLIGHT, batteryFeatureID, 0x0d, 0x00, 0x00, 0x00};
+      sendData(batteryCmd, sizeof(batteryCmd), false);
+    }
   }
 }
 
@@ -430,23 +442,19 @@ ssize_t SubDeviceConnection::sendData(const QByteArray& hidppMsg, bool checkDevi
   // pad the end of message with 0x00 to acheive the length of 20.
 
   QByteArray _hidppMsg(hidppMsg);
-  if (m_details.busType == BusType::Bluetooth) {
-    if (static_cast<uint8_t>(hidppMsg.at(1)) == 0xff){
+  if (m_deviceID.busType == BusType::Bluetooth) {
+    if (static_cast<uint8_t>(hidppMsg.at(1)) == MSG_TO_USB_RECEIVER){
       logDebug(hid) << "Invalid packet" << hidppMsg.toHex() << "for spotlight connected on bluetooth.";
       return res;
     }
 
-    if (hidppMsg.at(0) == 0x10) {
-      _hidppMsg.clear();
-      _hidppMsg.append(0x11);
-      _hidppMsg.append(hidppMsg.mid(1));
-      QByteArray padding(20 - _hidppMsg.length(), 0);
-      _hidppMsg.append(padding);
+    if (hidppMsg.at(0) == HIDPP_SHORT_MSG) {
+      _hidppMsg = HIDPP::shortToLongMsg(hidppMsg);
     }
   }
 
-  bool isValidMsg = (_hidppMsg.length() == 7 && _hidppMsg.at(0) == 0x10);             // HID++ short message
-  isValidMsg = isValidMsg || (_hidppMsg.length() == 20 && _hidppMsg.at(0) == 0x11);   // HID++ long message
+  bool isValidMsg = (_hidppMsg.length() == 7 && _hidppMsg.at(0) == HIDPP_SHORT_MSG);             // HID++ short message
+  isValidMsg = isValidMsg || (_hidppMsg.length() == 20 && _hidppMsg.at(0) == HIDPP_LONG_MSG);   // HID++ long message
 
   // If checkDeviceOnline is true then do not send the packet if device is not online/active.
   if (checkDeviceOnline && !isOnline()) {

--- a/src/device.h
+++ b/src/device.h
@@ -85,7 +85,7 @@ public:
   auto getBatteryInfo(){return m_batteryInfo;};
 
 public slots:
-  void setBatteryInfo(QByteArray batteryData);
+  void setBatteryInfo(const QByteArray& batteryData);
 
 signals:
   void subDeviceConnected(const DeviceId& id, const QString& path);
@@ -112,6 +112,7 @@ enum class DeviceFlag : uint32_t {
   KeyEvents      = 1 << 4,
 
   Vibrate        = 1 << 16,
+  HasBattery     = 1 << 17,
 };
 ENUM(DeviceFlag, DeviceFlags)
 

--- a/src/device.h
+++ b/src/device.h
@@ -10,23 +10,28 @@
 #include <linux/input.h>
 
 // -------------------------------------------------------------------------------------------------
+// Bus on which device is connected
+enum class BusType : uint16_t { Unknown, Usb, Bluetooth };
+
+// -------------------------------------------------------------------------------------------------
 struct DeviceId
 {
   uint16_t vendorId = 0;
   uint16_t productId = 0;
+  BusType busType = BusType::Unknown;
   QString phys; // should be sufficient to differentiate between two devices of the same type
                 // - not tested, don't have two devices of any type currently.
 
   inline bool operator==(const DeviceId& rhs) const {
-    return std::tie(vendorId, productId, phys) == std::tie(rhs.vendorId, rhs.productId, rhs.phys);
+    return std::tie(vendorId, productId, busType, phys) == std::tie(rhs.vendorId, rhs.productId, rhs.busType, rhs.phys);
   }
 
   inline bool operator!=(const DeviceId& rhs) const {
-    return std::tie(vendorId, productId, phys) != std::tie(rhs.vendorId, rhs.productId, rhs.phys);
+    return std::tie(vendorId, productId, busType, phys) != std::tie(rhs.vendorId, rhs.productId, rhs.busType, rhs.phys);
   }
 
   inline bool operator<(const DeviceId& rhs) const {
-    return std::tie(vendorId, productId, phys) < std::tie(rhs.vendorId, rhs.productId, rhs.phys);
+    return std::tie(vendorId, productId, busType, phys) < std::tie(rhs.vendorId, rhs.productId, rhs.busType, rhs.phys);
   }
 };
 
@@ -90,15 +95,17 @@ ENUM(DeviceFlag, DeviceFlags)
 
 // -----------------------------------------------------------------------------------------------
 struct SubDeviceConnectionDetails {
-  SubDeviceConnectionDetails(const QString& path, ConnectionType type, ConnectionMode mode)
-    : type(type), mode(mode), devicePath(path) {}
+  SubDeviceConnectionDetails(const QString& path, ConnectionType type, ConnectionMode mode, BusType busType)
+    : type(type), mode(mode), busType(busType), devicePath(path) {}
 
   ConnectionType type;
   ConnectionMode mode;
+  BusType busType;
   bool grabbed = false;
   DeviceFlags deviceFlags = DeviceFlags::NoFlags;
   QString phys;
   QString devicePath;
+  float hidProtocolVer = -1;   // set after ping to HID sub-device; If positive then Hidraw device is online.
 };
 
 // -------------------------------------------------------------------------------------------------
@@ -130,8 +137,15 @@ public:
   void disableWrite(); // disable sending data
   void enableWrite(); // enable sending data
 
-  ssize_t sendData(const QByteArray& hidppMsg);                          // Send HID++ Message to HIDraw connection
-  ssize_t sendData(const void* hidppMsg, size_t hidppMsgLen); // Send HID++ Message to HIDraw connection
+  // HID++ specific functions
+  void initSubDevice();
+  void resetSubDevice(struct timespec delay);
+  void pingSubDevice();
+  bool isOnline(){return (m_details.hidProtocolVer > 0);};
+  void setHIDProtocol(float p){m_details.hidProtocolVer = p;};
+  float getHIDProtocol(){return m_details.hidProtocolVer;};
+  ssize_t sendData(const QByteArray& hidppMsg, bool checkDeviceOnline = true);               // Send HID++ Message to HIDraw connection
+  ssize_t sendData(const void* hidppMsg, size_t hidppMsgLen, bool checkDeviceOnline = true); // Send HID++ Message to HIDraw connection
 
   auto type() const { return m_details.type; };
   auto mode() const { return m_details.mode; };
@@ -145,7 +159,7 @@ public:
   QSocketNotifier* socketWriteNotifier();  // Write notifier for Hidraw connection for sending data to device
 
 protected:
-  SubDeviceConnection(const QString& path, ConnectionType type, ConnectionMode mode);
+  SubDeviceConnection(const QString& path, ConnectionType type, ConnectionMode mode, BusType busType);
 
   SubDeviceConnectionDetails m_details;
   std::shared_ptr<InputMapper> m_inputMapper; // shared input mapper from parent device.

--- a/src/devicescan.cc
+++ b/src/devicescan.cc
@@ -135,8 +135,8 @@ namespace {
             const auto busType = ids.size() ? ids[0].toUShort(nullptr, 16) : 0;
             switch (busType)
             {
-              case BUS_USB: spotlightDevice.busType = DeviceScan::Device::BusType::Usb; break;
-              case BUS_BLUETOOTH: spotlightDevice.busType = DeviceScan::Device::BusType::Bluetooth; break;
+              case BUS_USB: spotlightDevice.id.busType = BusType::Usb; break;
+              case BUS_BLUETOOTH: spotlightDevice.id.busType = BusType::Bluetooth; break;
             }
             spotlightDevice.id.vendorId = ids.size() > 1 ? ids[1].toUShort(nullptr, 16) : 0;
             spotlightDevice.id.productId = ids.size() > 2 ? ids[2].toUShort(nullptr, 16) : 0;
@@ -154,7 +154,6 @@ namespace {
     }
     return spotlightDevice;
   }
-
 }
 
 namespace DeviceScan {
@@ -257,10 +256,9 @@ namespace DeviceScan {
         }
       }
 
-      // For now: only check for hidraw sub-devices that have support for custom "proprietary"
-      // functionality/protocol with Projecteur built in.
-      // TODO check if _Projecteur_ supports additional "proprietary" device protocol features..
-      if (eventSubDeviceCount > 0) continue;
+      // Spotlight (Bluetooth) have hidraw interface in the same folder. However
+      // for other connection, it has separate folder for hidraw device and input device.
+      if (!(rootDevice.id.busType == BusType::Bluetooth) && eventSubDeviceCount > 0) continue;
 
       // Iterate over 'hidraw' sub-dircectory, check for hidraw device node
       const QFileInfo hidrawSubdir(QDir(hidIt.filePath()).filePath("hidraw"));

--- a/src/devicescan.h
+++ b/src/devicescan.h
@@ -31,12 +31,10 @@ namespace DeviceScan
   };
 
   struct Device { // Structure for device scan results
-    enum class BusType : uint16_t { Unknown, Usb, Bluetooth };
     const QString& getName() const { return userName.size() ? userName : name; }
     QString name;
     QString userName;
     DeviceId id;
-    BusType busType = BusType::Unknown;
     std::vector<SubDevice> subDevices;
   };
 

--- a/src/deviceswidget.cc
+++ b/src/deviceswidget.cc
@@ -226,7 +226,7 @@ void DevicesWidget::updateDeviceDetails(Spotlight* spotlight)
       auto flagText = [](DeviceFlag f){
         QStringList flagList;
         if (!!(f & DeviceFlag::Vibrate)) flagList.push_back("Vibration");
-        if (!!(f & DeviceFlag::HasBattery)) flagList.push_back("Report_Battery");
+        if (!!(f & DeviceFlag::ReportBattery)) flagList.push_back("Report_Battery");
         return flagList;
       };
       for (const auto& sd: dc->subDevices()) {
@@ -248,8 +248,8 @@ void DevicesWidget::updateDeviceDetails(Spotlight* spotlight)
       if (d == BatteryStatus::AlmostFull) return "Almost Full";
       if (d == BatteryStatus::Full) return "Full Charge";
       if (d == BatteryStatus::SlowCharging) return "Slow Charging";
-      if (d == BatteryStatus::InvalidBattery || d == BatteryStatus::ThermalError) {
-        return "Battery Problem/Invalid Battery";
+      if (d == BatteryStatus::InvalidBattery || d == BatteryStatus::ThermalError || d == BatteryStatus::ChargingError) {
+        return "Charging Error";
       };
       return "";
     };
@@ -281,7 +281,7 @@ void DevicesWidget::updateDeviceDetails(Spotlight* spotlight)
                                         [](const auto& sd){
         return (sd.second->type() == ConnectionType::Hidraw &&
                 sd.second->mode() == ConnectionMode::ReadWrite &&
-                !!(sd.second->flags() & DeviceFlag::HasBattery));});
+                !!(sd.second->flags() & DeviceFlag::ReportBattery));});
 
     deviceDetails += tr("Name:\t\t%1\n").arg(dc->deviceName());
     deviceDetails += tr("VendorId:\t%1\n").arg(logging::hexId(dc->deviceId().vendorId));

--- a/src/deviceswidget.cc
+++ b/src/deviceswidget.cc
@@ -159,9 +159,14 @@ QWidget* DevicesWidget::createDevicesWidget(Settings* settings, Spotlight* spotl
     m_vibrationSettingsWidget->setSubDeviceConnection(conn.get());
   }
 
+  m_deviceDetailsTabWidget = createDeviceInfoWidget(spotlight);
+  tabWidget->addTab(m_deviceDetailsTabWidget, tr("Details"));
+
   connect(this, &DevicesWidget::currentDeviceChanged, this,
   [vibrateConn=std::move(vibrateConn), tabWidget, settings, spotlight, this]
   (const DeviceId& devId) {
+    const auto idx = tabWidget->indexOf(m_deviceDetailsTabWidget);
+    if (idx >= 0) tabWidget->removeTab(idx);
     if (const auto conn = vibrateConn(devId)) {
       if (m_timerTabWidget == nullptr) {
         m_timerTabWidget = createTimerTabWidget(settings, spotlight);
@@ -176,20 +181,140 @@ QWidget* DevicesWidget::createDevicesWidget(Settings* settings, Spotlight* spotl
       if (idx >= 0) tabWidget->removeTab(idx);
       m_vibrationSettingsWidget->setSubDeviceConnection(nullptr);
     }
+    // ensure that Details tab is last tab
+    tabWidget->addTab(m_deviceDetailsTabWidget, tr("Details"));
+
+    tabWidget->setCurrentIndex(0);
   });
 
   return dw;
 }
 
 // -------------------------------------------------------------------------------------------------
-QWidget* DevicesWidget::createDeviceInfoWidget(Spotlight* /*spotlight*/)
+void DevicesWidget::updateDeviceDetails(Spotlight* spotlight)
+{
+  auto updateBatteryInfo = [this, spotlight]() {
+    auto curDeviceId = currentDeviceId();
+    if (curDeviceId == invalidDeviceId)
+      return;
+    auto dc = spotlight->deviceConnection(curDeviceId);
+    dc->queryBatteryStatus();
+  };
+
+  auto getDeviceDetails = [this, spotlight]() {
+    QString deviceDetails;
+    auto curDeviceId = currentDeviceId();
+    if (curDeviceId == invalidDeviceId)
+      return tr("No Device Connected");
+    auto dc = spotlight->deviceConnection(curDeviceId);
+
+    const auto busTypeToString = [](BusType type) -> QString {
+      if (type == BusType::Usb) return "USB";
+      if (type == BusType::Bluetooth) return "Bluetooth";
+      return "Unknown";
+    };
+
+    const QStringList subDeviceList = [dc](){
+      QStringList subDeviceList;
+      auto accessText = [](ConnectionMode m){
+        if (m == ConnectionMode::ReadOnly) return "ReadOnly";
+        if (m == ConnectionMode::WriteOnly) return "WriteOnly";
+        if (m == ConnectionMode::ReadWrite) return "ReadWrite";
+        return "Unknown Access";
+      };
+      // report special flags set by program (like vibration and others)
+      auto flagText = [](DeviceFlag f){
+        QStringList flagList;
+        if (!!(f & DeviceFlag::Vibrate)) flagList.push_back("Vibration");
+        return flagList;
+      };
+      for (const auto& sd: dc->subDevices()) {
+        if (sd.second->path().size()) {
+          auto sds = sd.second;
+          auto flagInfo = flagText(sds->flags());
+          subDeviceList.push_back(tr("%1\t[%2, %3, %4]").arg(sds->path(),
+                                                     accessText(sds->mode()),
+                                                     sds->isGrabbed()?"Grabbed":"",
+                                                     flagInfo.isEmpty()?"":"Supports: " + flagInfo.join("; ")
+                                                     ));
+        }
+      }
+      return subDeviceList;
+    }();
+    auto batteryStatusText = [](BatteryStatus d){
+      if (d == BatteryStatus::Discharging) return "Discharging";
+      if (d == BatteryStatus::Charging) return "Charging";
+      if (d == BatteryStatus::AlmostFull) return "Almost Full";
+      if (d == BatteryStatus::Full) return "Full Charge";
+      if (d == BatteryStatus::SlowCharging) return "Slow Charging";
+      if (d == BatteryStatus::InvalidBattery || d == BatteryStatus::ThermalError) {
+        return "Battery Problem/Invalid Battery";
+      };
+      return "";
+    };
+
+    auto batteryInfoText = [dc, batteryStatusText](){
+      auto sDevices = dc->subDevices();
+      const bool isOnline = std::any_of(sDevices.cbegin(), sDevices.cend(),
+            [](const auto& sd){
+              return (sd.second->type() == ConnectionType::Hidraw &&
+                      sd.second->mode() == ConnectionMode::ReadWrite &&
+                      sd.second->isOnline());
+            });
+      if (isOnline) {
+        auto batteryInfo= dc->getBatteryInfo();
+        // Only show battery percent while discharging.
+        // Other cases, device do not report battery percentage correctly.
+        if (batteryInfo.status == BatteryStatus::Discharging) {
+          return tr("%1\% - %2% (%3)").arg(
+                      QString::number(batteryInfo.currentLevel),
+                      QString::number(batteryInfo.nextReportedLevel),
+                      batteryStatusText(batteryInfo.status));
+        } else {
+          return tr("%3").arg(batteryStatusText(batteryInfo.status));
+        }
+      } else {
+        return tr("Device not active. Press any key on device to update.");
+      }
+    };
+
+    deviceDetails += tr("Name:\t\t%1\n").arg(dc->deviceName());
+    deviceDetails += tr("VendorId:\t%1\n").arg(logging::hexId(dc->deviceId().vendorId));
+    deviceDetails += tr("ProductId:\t%1\n").arg(logging::hexId(dc->deviceId().productId));
+    deviceDetails += tr("Phys:\t\t%1\n").arg(dc->deviceId().phys);
+    deviceDetails += tr("Bus Type:\t%1\n").arg(busTypeToString(dc->deviceId().busType));
+    deviceDetails += tr("Sub-Devices:\t%1\n").arg(subDeviceList.join(",\n\t\t"));
+    deviceDetails += tr("Battery Status:\t%1\n").arg(batteryInfoText());
+
+    return deviceDetails;
+  };
+
+
+  updateBatteryInfo();
+  if (m_deviceDetailsTextEdit) {
+    QTimer::singleShot(1000, this, [this, getDeviceDetails](){m_deviceDetailsTextEdit->setText(getDeviceDetails());});
+  }
+}
+
+// -------------------------------------------------------------------------------------------------
+QWidget* DevicesWidget::createDeviceInfoWidget(Spotlight* spotlight)
 {
   const auto diWidget = new QWidget(this);
   const auto layout = new QHBoxLayout(diWidget);
-  layout->addStretch(1);
-  layout->addWidget(new QLabel(tr("Not yet implemented"), this));
-  layout->addStretch(1);
-  diWidget->setDisabled(true);
+  if (!m_deviceDetailsTextEdit) m_deviceDetailsTextEdit = new QTextEdit(this);
+  m_deviceDetailsTextEdit->setReadOnly(true);
+  m_deviceDetailsTextEdit->setText("");
+
+  updateDeviceDetails(spotlight);
+
+  connect(m_updateDeviceDetailsTimer, &QTimer::timeout, this, [this, spotlight](){updateDeviceDetails(spotlight);});
+  m_updateDeviceDetailsTimer->start(900000);  // Update every 15 minutes
+
+  connect(this, &DevicesWidget::currentDeviceChanged, this, [this, spotlight](){updateDeviceDetails(spotlight);});
+  connect(spotlight, &Spotlight::deviceActivated, this,
+          [this, spotlight](const DeviceId& d){if (d==currentDeviceId()){ updateDeviceDetails(spotlight);};});
+
+  layout->addWidget(m_deviceDetailsTextEdit);
   return diWidget;
 }
 

--- a/src/deviceswidget.h
+++ b/src/deviceswidget.h
@@ -5,6 +5,7 @@
 #include <QWidget>
 #include <QTextEdit>
 #include <QTimer>
+#include <QTabWidget>
 
 struct DeviceId;
 class InputMapper;

--- a/src/deviceswidget.h
+++ b/src/deviceswidget.h
@@ -3,6 +3,8 @@
 
 #include <QPointer>
 #include <QWidget>
+#include <QTextEdit>
+#include <QTimer>
 
 struct DeviceId;
 class InputMapper;
@@ -30,9 +32,13 @@ private:
   QWidget* createInputMapperWidget(Settings* settings, Spotlight* spotlight);
   QWidget* createDeviceInfoWidget(Spotlight* spotlight);
   QWidget* createTimerTabWidget(Settings* settings, Spotlight* spotlight);
+  void updateDeviceDetails(Spotlight* spotlight);
 
   QComboBox* m_devicesCombo = nullptr;
   QWidget* m_timerTabWidget = nullptr;
+  QWidget* m_deviceDetailsTabWidget = nullptr;
+  QTextEdit* m_deviceDetailsTextEdit = nullptr;
+  QTimer* m_updateDeviceDetailsTimer = new QTimer(this);
   VibrationSettingsWidget* m_vibrationSettingsWidget = nullptr;
   QPointer<InputMapper> m_inputMapper;
 };

--- a/src/hidpp.cc
+++ b/src/hidpp.cc
@@ -4,81 +4,155 @@
 
 #include <unistd.h>
 
+#include <QTime>
+
 DECLARE_LOGGING_CATEGORY(hid)
 
 // -------------------------------------------------------------------------------------------------
-void FeatureSet::populateFeatureTable(){
-  if (m_fHIDDevice) {
-    auto getResponse = [this](QByteArray expectedBytes){
-      QByteArray readVal(20, 0);
-      while(true) {
-        if(::read(m_fHIDDevice, readVal.data(), readVal.length())) {
-          //logInfo(hid) << "Received" << readVal.toHex() << "Expected" << expectedBytes.toHex();
-          if (readVal.mid(1, 3) == expectedBytes) return readVal;
-          if (static_cast<uint8_t>(readVal.at(2)) == 0x8f) return readVal;  //Device not online
-          if (errno != EAGAIN) return QByteArray(20, 0x8f);
-        }
-      }
-    };
-    // To get firmware details: first get Feature ID corresponding to Firmware feature code
-    // and then make final request to get firmware version using the obtained feature ID
-    uint8_t fwLSB = static_cast<uint8_t>(static_cast<uint16_t>(FeatureCode::FirmwareVersion) >> 8);   //0x00
-    uint8_t fwMSB = static_cast<uint8_t>(static_cast<uint16_t>(FeatureCode::FirmwareVersion));        //0x03
-    uint8_t fwIDReq[] = {0x11, 0x01, 0x00, 0x0d, fwLSB, fwMSB, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-    const QByteArray fwReqArr(reinterpret_cast<const char*>(fwIDReq), sizeof(fwIDReq));
-    ::write(m_fHIDDevice, fwReqArr.data(), fwReqArr.length());
-    auto response = getResponse(fwReqArr.mid(1, 3));
-    if (static_cast<uint8_t>(response.at(2)) == 0x8f) return;
-    uint8_t fwID = static_cast<uint8_t>(response.at(4));
+QByteArray FeatureSet::getResponseFromDevice(QByteArray expectedBytes)
+{
+  if (m_fdHIDDevice == -1) return QByteArray();
 
-    // Get the firmware version now
-    uint8_t fwVerReq[] = {0x11, 0x01, fwID, 0x0d, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+  QByteArray readVal(20, 0);
+  int timeOut = 4; // time out just in case device did not reply;
+                   // 4 seconds time out is used by other prorams like Solaar.
+  QTime timeOutTime = QTime::currentTime().addSecs(timeOut);
+  while(true) {
+    if(::read(m_fdHIDDevice, readVal.data(), readVal.length())) {
+      if (readVal.mid(1, 3) == expectedBytes) return readVal;
+      if (static_cast<uint8_t>(readVal.at(2)) == 0x8f) return readVal;  //Device not online
+      if (QTime::currentTime() >= timeOutTime) return QByteArray();
+    }
+  }
+}
+
+// -------------------------------------------------------------------------------------------------
+uint8_t FeatureSet::getFeatureIDFromDevice(FeatureCode fc)
+{
+  if (m_fdHIDDevice == -1) return 0x00;
+
+  uint8_t fSetLSB = static_cast<uint8_t>(static_cast<uint16_t>(fc) >> 8);
+  uint8_t fSetMSB = static_cast<uint8_t>(static_cast<uint16_t>(fc));
+  uint8_t featureIDReq[] = {HIDPP_LONG_MSG, MSG_TO_SPOTLIGHT, 0x00, 0x0d, fSetLSB, fSetMSB, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+  const QByteArray featureIDReqArr(reinterpret_cast<const char*>(featureIDReq), sizeof(featureIDReq));
+  ::write(m_fdHIDDevice, featureIDReqArr.data(), featureIDReqArr.length());
+
+  auto response = getResponseFromDevice(featureIDReqArr.mid(1, 3));
+  if (!response.length() || static_cast<uint8_t>(response.at(2)) == 0x8f) return 0x00;
+  uint8_t featureID = static_cast<uint8_t>(response.at(4));
+
+  return featureID;
+}
+
+// -------------------------------------------------------------------------------------------------
+uint8_t FeatureSet::getFeatureCountFromDevice(uint8_t featureSetID)
+{
+  if (m_fdHIDDevice == -1) return 0x00;
+
+  // Get Number of features (except Root Feature) supported
+  uint8_t featureCountReq[] = {HIDPP_LONG_MSG, MSG_TO_SPOTLIGHT, featureSetID, 0x0d, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+  const QByteArray featureCountReqArr(reinterpret_cast<const char*>(featureCountReq), sizeof(featureCountReq));
+  ::write(m_fdHIDDevice, featureCountReqArr.data(), featureCountReqArr.length());
+  auto response = getResponseFromDevice(featureCountReqArr.mid(1, 3));
+  if (!response.length() || static_cast<uint8_t>(response.at(2)) == 0x8f) return 0x00;
+  uint8_t featureCount = static_cast<uint8_t>(response.at(4));
+
+  return featureCount;
+}
+
+// -------------------------------------------------------------------------------------------------
+QByteArray FeatureSet::getFirmwareVersionFromDevice()
+{
+  if (m_fdHIDDevice == -1) return 0x00;
+
+  // To get firmware details: first get Feature ID corresponding to Firmware feature code
+  uint8_t fwID = getFeatureIDFromDevice(FeatureCode::FirmwareVersion);
+  if (!fwID) return QByteArray();
+
+  // Get the number of firmwares (Main HID++ application, BootLoader, or Hardware) now
+  uint8_t fwCountReq[] = {HIDPP_LONG_MSG, MSG_TO_SPOTLIGHT, fwID, 0x0d, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+  const QByteArray fwCountReqArr(reinterpret_cast<const char*>(fwCountReq), sizeof(fwCountReq));
+  ::write(m_fdHIDDevice, fwCountReqArr.data(), fwCountReqArr.length());
+  auto response = getResponseFromDevice(fwCountReqArr.mid(1, 3));
+  if (!response.length() || static_cast<uint8_t>(response.at(2)) == 0x8f) return  QByteArray();
+  uint8_t fwCount = static_cast<uint8_t>(response.at(4));
+
+  // The following info is not used currently; however, these commented lines are kept for future reference.
+  // uint8_t connectionMode = static_cast<uint8_t>(response.at(10));
+  // bool supportBluetooth = (connectionMode & 0x01);
+  // bool supportBluetoothLE = (connectionMode & 0x02);  // true for Logitech Spotlight
+  // bool supportUsbReceiver = (connectionMode & 0x04);  // true for Logitech Spotlight
+  // bool supportUsbWired = (connectionMode & 0x08);
+  // auto unitID = response.mid(5, 4);
+  // auto modelIDs = response.mid(11, 8);
+  // int count = 0;
+  // if (supportBluetooth) { auto btmodelID = modelIDs.mid(count, 2); count += 2;}
+  // if (supportBluetoothLE) { auto btlemodelID = modelIDs.mid(count, 2); count += 2;}
+  // if (supportUsbReceiver) { auto wpmodelID = modelIDs.mid(count, 2); count += 2;}
+  // if (supportUsbWired) { auto usbmodelID = modelIDs.mid(count, 2); count += 2;}
+
+
+  // Iteratively find out firmware version for all firmwares and get the firmware for main application
+  for (uint8_t i = 0x00; i < fwCount; i++)
+  {
+    uint8_t fwVerReq[] = {HIDPP_LONG_MSG, MSG_TO_SPOTLIGHT, fwID, 0x1d, i, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
     const QByteArray fwVerReqArr(reinterpret_cast<const char*>(fwVerReq), sizeof(fwVerReq));
-    ::write(m_fHIDDevice, fwVerReqArr.data(), fwVerReqArr.length());
-    auto fwResponse1 = getResponse(fwVerReqArr.mid(1, 3));
-    if (static_cast<uint8_t>(fwResponse1.at(2)) == 0x8f) return;
+    ::write(m_fdHIDDevice, fwVerReqArr.data(), fwVerReqArr.length());
+    auto fwResponse = getResponseFromDevice(fwVerReqArr.mid(1, 3));
+    if (!fwResponse.length() || static_cast<uint8_t>(fwResponse.at(2)) == 0x8f) return QByteArray();
+    auto fwType = (fwResponse.at(4) & 0x0f);  // 0 for main HID++ application, 1 for BootLoader, 2 for Hardware, 3-15 others
+    auto fwVersion = fwResponse.mid(5, 7);
+    // Currently we are not interested in these details; however, these commented lines are kept for future reference.
+    //auto firmwareName = fwVersion.mid(0, 3).data();
+    //auto majorVesion = fwResponse.at(3);
+    //auto MinorVersion = fwResponse.at(4);
+    //auto build = fwResponse.mid(5);
+    if (fwType == 0)
+    {
+      logDebug(hid) << "Main application firmware Version:" << fwVersion.toHex();
+      return fwVersion;
+    }
+  }
+  return QByteArray();
+}
 
-    uint8_t fwVer2Req[] = {0x11, 0x01, fwID, 0x1d, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-    const QByteArray fwVer2ReqArr(reinterpret_cast<const char*>(fwVer2Req), sizeof(fwVer2Req));
-    ::write(m_fHIDDevice, fwVer2ReqArr.data(), fwVer2ReqArr.length());
-    auto fwResponse2 = getResponse(fwVer2ReqArr.mid(1, 3));
-    if (static_cast<uint8_t>(fwResponse2.at(2)) == 0x8f) return;
-    //TODO:: make sense of fwResponse1 and fwResponse2
+// -------------------------------------------------------------------------------------------------
+void FeatureSet::populateFeatureTable()
+{
+  if (m_fdHIDDevice == -1) return;
 
-    // TODO:: Read and write cache file
-    // if the firmware details match with cached file; then load the FeatureTable from file
-    // else read the entire feature table from the device
+  // Get the firmware version
+  auto firmwareVersion = getFirmwareVersionFromDevice();
+  if (!firmwareVersion.length()) return;
 
+  // TODO:: Read and write cache file (settings most probably)
+  // if the firmware details match with cached file; then load the FeatureTable from file
+  // else read the entire feature table from the device
+  QByteArray cacheFirmwareVersion;  // currently a dummy variable for Firmware Version from cache file.
 
+  if (firmwareVersion == cacheFirmwareVersion)
+  {
+    // TODO: load the featureSet from the cache file
+
+  } else {
     // For reading feature table from device
-    // first get the Feature Index for Feature Set
-    uint8_t fSetLSB = static_cast<uint8_t>(static_cast<uint16_t>(FeatureCode::FeatureSet) >> 8);   //0x00
-    uint8_t fSetMSB = static_cast<uint8_t>(static_cast<uint16_t>(FeatureCode::FeatureSet));        //0x01
-    uint8_t featureSetIDReq[] = {0x11, 0x01, 0x00, 0x0d, fSetLSB, fSetMSB, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-    const QByteArray featureSetIDReqArr(reinterpret_cast<const char*>(featureSetIDReq), sizeof(featureSetIDReq));
-    ::write(m_fHIDDevice, featureSetIDReqArr.data(), featureSetIDReqArr.length());
-    response = getResponse(featureSetIDReqArr.mid(1, 3));
-    if (static_cast<uint8_t>(response.at(2)) == 0x8f) return;
-    uint8_t featureSetID = static_cast<uint8_t>(response.at(4));
+    // first get featureID for FeatureCode::FeatureSet
+    // then we can get the number of features supported by the device (except Root Feature)
+    uint8_t featureSetID = getFeatureIDFromDevice(FeatureCode::FeatureSet);
+    if (!featureSetID) return;
+    uint8_t featureCount = getFeatureCountFromDevice(featureSetID);
+    if (!featureCount) return;
 
-    // Get Number of features (except Root Feature) supported
-    uint8_t featureCountReq[] = {0x11, 0x01, featureSetID, 0x0d, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-    const QByteArray featureCountReqArr(reinterpret_cast<const char*>(featureCountReq), sizeof(featureCountReq));
-    ::write(m_fHIDDevice, featureCountReqArr.data(), featureCountReqArr.length());
-    response = getResponse(featureCountReqArr.mid(1, 3));
-    if (static_cast<uint8_t>(response.at(2)) == 0x8f) return;
-    uint8_t featureCount = static_cast<uint8_t>(response.at(4));
-
-    // Root feature is supported by all HID++ 2.0 device and has a featureID of 0
+    // Root feature is supported by all HID++ 2.0 device and has a featureID of 0 always.
     m_featureTable.insert({static_cast<uint16_t>(FeatureCode::Root), 0x00});
 
-    // Read Feature Code for other featureIds from device
+    // Read Feature Code for other featureIds from device.
     for (uint8_t featureId = 0x01; featureId <= featureCount; featureId++) {
-      const uint8_t data[] = {0x11, 0x01, featureSetID, 0x1d, featureId, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+      const uint8_t data[] = {HIDPP_LONG_MSG, MSG_TO_SPOTLIGHT, featureSetID, 0x1d, featureId, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
       const QByteArray dataArr(reinterpret_cast<const char*>(data), sizeof(data));
-      ::write(m_fHIDDevice, dataArr.data(), dataArr.length());
-      response = getResponse(dataArr.mid(1, 3));
-      if (static_cast<uint8_t>(response.at(2)) == 0x8f) {
+      ::write(m_fdHIDDevice, dataArr.data(), dataArr.length());
+      auto response = getResponseFromDevice(dataArr.mid(1, 3));
+      if (!response.length() || static_cast<uint8_t>(response.at(2)) == 0x8f) {
         m_featureTable.clear();
         return;
       }
@@ -86,9 +160,7 @@ void FeatureSet::populateFeatureTable(){
       uint8_t featureType = static_cast<uint8_t>(response.at(6));
       auto softwareHidden = (featureType & (1<<6));
       auto obsoleteFeature = (featureType & (1<<7));
-      if (!(softwareHidden) && !(obsoleteFeature)) {
-        m_featureTable.insert({featureCode, featureId});
-      }
+      if (!(softwareHidden) && !(obsoleteFeature)) m_featureTable.insert({featureCode, featureId});
     }
   }
 }
@@ -107,4 +179,19 @@ uint8_t FeatureSet::getFeatureID(FeatureCode fc)
 
   auto featurePair = m_featureTable.find(static_cast<uint16_t>(fc));
   return featurePair->second;
+}
+
+// -------------------------------------------------------------------------------------------------
+QByteArray HIDPP::shortToLongMsg(QByteArray shortMsg)
+{
+  bool isValidShortMsg = (shortMsg.at(0) == HIDPP_SHORT_MSG && shortMsg.length() == 7);
+
+  if (isValidShortMsg) {
+    QByteArray longMsg;
+    longMsg.append(HIDPP_LONG_MSG);
+    longMsg.append(shortMsg.mid(1));
+    QByteArray padding(20 - longMsg.length(), 0);
+    longMsg.append(padding);
+    return longMsg;
+  } else return shortMsg;
 }

--- a/src/hidpp.h
+++ b/src/hidpp.h
@@ -6,6 +6,19 @@
 #include <QObject>
 #include <QFile>
 
+#define HIDPP_SHORT_MSG                         0x10
+#define HIDPP_LONG_MSG                          0x11
+
+#define MSG_TO_USB_RECEIVER                     0xff
+#define MSG_TO_SPOTLIGHT                        0x01   // Spotlight is first device on the receiver (bluetooth also uses this code)
+
+#define HIDPP_SHORT_GET_FEATURE                 0x81
+#define HIDPP_SHORT_SET_FEATURE                 0x80
+
+#define HIDPP_SHORT_WIRELESS_NOTIFICATION_CODE  0x41
+
+
+
 // Feature Codes important for Logitech Spotlight
 enum class FeatureCode : uint16_t {
   Root                 = 0x0000,
@@ -15,8 +28,6 @@ enum class FeatureCode : uint16_t {
   Reset                = 0x0020,
   DFUControlSigned     = 0x00c2,
   BatteryStatus        = 0x1000,
-  BatteryVoltage       = 0x1001,
-  BatteryUnified       = 0x1004,
   PresenterControl     = 0x1a00,
   Sensor3D             = 0x1a01,
   ReprogramControlsV4  = 0x1b04,
@@ -25,21 +36,29 @@ enum class FeatureCode : uint16_t {
   PointerSpeed         = 0x2205,
 };
 
+namespace HIDPP {
+QByteArray shortToLongMsg(QByteArray shortMsg);  // used for bluetooth connections
+}
 
+// Class to get and store Set of supported features for a HID++ 2.0 device
 class FeatureSet
 {
 public:
   FeatureSet() {};
   virtual ~FeatureSet() {}
 
-  void setHIDDeviceFileDescriptor(int fd) { m_fHIDDevice = fd; };
+  void setHIDDeviceFileDescriptor(int fd) { m_fdHIDDevice = fd; }
   uint8_t getFeatureID(FeatureCode fc);
   bool supportFeatureCode(FeatureCode fc);
   auto getFeatureCount() { return m_featureTable.size(); }
   void populateFeatureTable();
-  bool hasFeatureTable(){ return !(m_featureTable.empty()); }
 
 protected:
+  uint8_t getFeatureIDFromDevice(FeatureCode fc);
+  uint8_t getFeatureCountFromDevice(uint8_t featureSetID);
+  QByteArray getFirmwareVersionFromDevice();
+  QByteArray getResponseFromDevice(QByteArray expectedBytes);
+
   std::map<uint16_t, uint8_t> m_featureTable;
-  int m_fHIDDevice=0;
+  int m_fdHIDDevice = -1;
 };

--- a/src/main.cc
+++ b/src/main.cc
@@ -231,9 +231,9 @@ int main(int argc, char *argv[])
               << Main::tr(" * Found %1 supported devices. (%2 readable, %3 writable)")
                  .arg(result.devices.size()).arg(result.numDevicesReadable).arg(result.numDevicesWritable);
 
-      const auto busTypeToString = [](DeviceScan::Device::BusType type) -> QString {
-        if (type == DeviceScan::Device::BusType::Usb) return "USB";
-        if (type == DeviceScan::Device::BusType::Bluetooth) return "Bluetooth";
+      const auto busTypeToString = [](BusType type) -> QString {
+        if (type == BusType::Usb) return "USB";
+        if (type == BusType::Bluetooth) return "Bluetooth";
         return "unknown";
       };
 
@@ -266,7 +266,7 @@ int main(int argc, char *argv[])
         print() << "     " << "vendorId:  " << logging::hexId(device.id.vendorId);
         print() << "     " << "productId: " << logging::hexId(device.id.productId);
         print() << "     " << "phys:      " << device.id.phys;
-        print() << "     " << "busType:   " << busTypeToString(device.busType);
+        print() << "     " << "busType:   " << busTypeToString(device.id.busType);
         print() << "     " << "devices:   " << subDeviceList.join(", ");
         print() << "     " << "readable:  " << (allReadable ? "true" : "false");
         print() << "     " << "writable:  " << (allWriteable ? "true" : "false");

--- a/src/preferencesdlg.cc
+++ b/src/preferencesdlg.cc
@@ -103,7 +103,6 @@ PreferencesDialog::PreferencesDialog(Settings* settings, Spotlight* spotlight,
 
   connect(overlayCheckBox, &QCheckBox::toggled, this, [settings](bool checked){
     settings->setOverlayDisabled(!checked);
-
   });
 
   connect(settings, &Settings::overlayDisabledChanged, this,

--- a/src/spotlight.cc
+++ b/src/spotlight.cc
@@ -133,7 +133,13 @@ int Spotlight::connectDevices()
           if (addInputEventHandler(devCon)) return devCon;
         } else if (scanSubDevice.type == DeviceScan::SubDevice::Type::Hidraw) {
           auto hidCon = SubHidrawConnection::create(scanSubDevice, *dc);
-          if(addHIDInputHandler(hidCon)) return hidCon;
+          if(addHIDInputHandler(hidCon)) {
+            connect(hidCon.get(), &SubHidrawConnection::receivedBatteryInfo,
+                    dc.get(), &DeviceConnection::setBatteryInfo);
+            connect(hidCon.get(), &SubHidrawConnection::receivedPingResponse,
+                    dc.get(), [this, dc](){emit deviceActivated(dc->deviceId(), dc->deviceName());});
+            return hidCon;
+          }
         }
         return std::shared_ptr<SubDeviceConnection>();
       }();
@@ -318,15 +324,24 @@ void Spotlight::onHIDDataAvailable(int fd, SubHidrawConnection& connection)
 
   if (readVal.at(0) == 0x11)    // Logitech HIDPP LONG message: 20 byte long
   {
-    if (readVal.at(2) == 0x00 && readVal.at(3) == 0x1d && readVal.at(6) == 0x5d) // response to ping
-    {
-      auto protocolVer = static_cast<uint8_t>(readVal.at(4)) + static_cast<uint8_t>(readVal.at(5))/10.0;
-      logDebug(hid) << connection.path() << "is online with protocol version" << protocolVer ;
-      connection.setHIDProtocol(protocolVer);
+    if (readVal.at(2) == 0x00) {
+      if (readVal.at(3) == 0x1d && readVal.at(6) == 0x5d) { // response to ping
+        auto protocolVer = static_cast<uint8_t>(readVal.at(4)) + static_cast<uint8_t>(readVal.at(5))/10.0;
+        logDebug(hid) << connection.path() << "is online with protocol version" << protocolVer ;
+        connection.setHIDProtocol(protocolVer);
+        if (connection.isOnline()) emit connection.receivedPingResponse();
+      }
     }
+
     if (readVal.at(2) == 0x04) {    // Logitech spotlight presenter unit got online.
       connection.initSubDevice();
     }
+
+    if (readVal.at(2) == 0x06 && readVal.at(3) == 0x0d) {  // Battery information packet
+      QByteArray batteryData(readVal.mid(4, 3));
+      emit connection.receivedBatteryInfo(batteryData);
+    }
+
     // TODO: Process other packets
 
     if (readVal.at(2) == 0x09 && readVal.at(3) == 0x1a) {

--- a/src/spotlight.cc
+++ b/src/spotlight.cc
@@ -139,18 +139,10 @@ int Spotlight::connectDevices()
         } else if (scanSubDevice.type == DeviceScan::SubDevice::Type::Hidraw) {
           auto hidCon = SubHidrawConnection::create(scanSubDevice, *dc);
           if(addHIDInputHandler(hidCon)) {
-            if (dc->deviceId().vendorId == 0x46d && hidCon->getFeatureSet()->getFeatureCount() == 0) {
-              //reconnect device to get the feature table
-              connect(hidCon.get(), &SubHidrawConnection::receivedPingResponse,
-                      this, [this, hidCon](){
-                  removeDeviceConnection(hidCon->path());
-                  connectDevices();});
-            } else {
               connect(hidCon.get(), &SubHidrawConnection::receivedBatteryInfo,
                     dc.get(), &DeviceConnection::setBatteryInfo);
               connect(hidCon.get(), &SubHidrawConnection::receivedPingResponse,
                     dc.get(), [this, dc](){emit deviceActivated(dc->deviceId(), dc->deviceName());});
-            }
             return hidCon;
           }
           if(addHIDInputHandler(hidCon)) return hidCon;
@@ -330,29 +322,28 @@ void Spotlight::onHIDDataAvailable(int fd, SubHidrawConnection& connection)
   }
 
   // Only process HID++ packets (hence, the packets starting with 0x10 or 0x11)
-  if (!(readVal.at(0) == 0x10 || readVal.at(0) == 0x11)) {
+  if (!(readVal.at(0) == HIDPP_SHORT_MSG || readVal.at(0) == HIDPP_LONG_MSG)) {
     return;
   }
 
   logDebug(hid) << "Received" << readVal.toHex() << "from" << connection.path();
 
-  if (readVal.at(0) == 0x10)    // Logitech HIDPP SHORT message: 7 byte long
+  if (readVal.at(0) == HIDPP_SHORT_MSG)    // Logitech HIDPP SHORT message: 7 byte long
   {
-    if (readVal.at(2) == 0x41 && !!(readVal.at(3) & 0x04)) {    // wireless notification from USB dongle
-      if (readVal.at(4) & (1<<6)) {    // connection between USB dongle and spotlight device broke
+    if (readVal.at(2) == HIDPP_SHORT_WIRELESS_NOTIFICATION_CODE) {    // wireless notification from USB dongle
+      auto connection_status = readVal.at(4) & (1<<6);  // should be zero for successful connection
+      if (connection_status) {    // connection between USB dongle and spotlight device broke
         connection.setHIDProtocol(-1);
       } else {                         // Logitech spotlight presenter unit got online and USB dongle acknowledged it.
-        // currently it is off as I observed that device send two online packet
-        // one with 0x10 and other with 0x11. Currently initsubDevice is triggered
-        // on 0x11 packet.
-        //connection.initSubDevice();
+        if (!connection.isOnline()) connection.initSubDevice();
       }
     }
   }
 
-  if (readVal.at(0) == 0x11)    // Logitech HIDPP LONG message: 20 byte long
+  if (readVal.at(0) == HIDPP_LONG_MSG)    // Logitech HIDPP LONG message: 20 byte long
   {
-    if (readVal.at(2) == 0x00) {
+    auto rootID = connection.getFeatureSet()->getFeatureID(FeatureCode::Root);
+    if (readVal.at(2) == rootID) {
       if (readVal.at(3) == 0x1d && readVal.at(6) == 0x5d) { // response to ping
         auto protocolVer = static_cast<uint8_t>(readVal.at(4)) + static_cast<uint8_t>(readVal.at(5))/10.0;
         connection.setHIDProtocol(protocolVer);
@@ -360,18 +351,23 @@ void Spotlight::onHIDDataAvailable(int fd, SubHidrawConnection& connection)
       }
     }
 
-    if (readVal.at(2) == 0x04) {    // Logitech spotlight presenter unit got online.
-      connection.initSubDevice();
+    auto wirelessNotificationID = connection.getFeatureSet()->getFeatureID(FeatureCode::WirelessDeviceStatus);
+    if (wirelessNotificationID && readVal.at(2) == wirelessNotificationID) {    // Logitech spotlight presenter unit got online.
+      if (!connection.isOnline()) connection.initSubDevice();
     }
 
-    if (readVal.at(2) == 0x06 && readVal.at(3) == 0x0d) {  // Battery information packet
+    // Battery packet processing: Device responded to BatteryStatus (0x1000) packet
+    auto batteryID = connection.getFeatureSet()->getFeatureID(FeatureCode::BatteryStatus);
+    if (batteryID && readVal.at(2) == batteryID && readVal.at(3) == 0x0d) {  // Battery information packet
       QByteArray batteryData(readVal.mid(4, 3));
       emit connection.receivedBatteryInfo(batteryData);
     }
 
     // TODO: Process other packets
 
-    if (readVal.at(2) == 0x09 && readVal.at(3) == 0x1d) {
+    // Vibration response check
+    const uint8_t pcID = connection.getFeatureSet()->getFeatureID(FeatureCode::PresenterControl);
+    if (pcID && readVal.at(2) == pcID && readVal.at(3) == 0x1d) {
       logDebug(hid) << "Device acknowledged a vibration event.";
     }
   }

--- a/src/spotlight.cc
+++ b/src/spotlight.cc
@@ -329,12 +329,15 @@ void Spotlight::onHIDDataAvailable(int fd, SubHidrawConnection& connection)
 
   if (readVal.at(0) == 0x10)    // Logitech HIDPP SHORT message: 7 byte long
   {
-    if (readVal.at(2) == 0x41 && !!(readVal.at(3) & 0x04) &&
-                                    !(readVal.at(4) & 1<<6)) {    // Logitech spotlight presenter unit got online and USB dongle acknowledged it.
-      // currently it is off as I observed that device send two online packet
-      // one with 0x10 and other with 0x11. Currently initsubDevice is triggered
-      // on 0x11 packet.
-      //connection.initSubDevice();
+    if (readVal.at(2) == 0x41 && !!(readVal.at(3) & 0x04)) {    // wireless notification from USB dongle
+      if (readVal.at(4) & (1<<6)) {    // connection between USB dongle and spotlight device broke
+        connection.setHIDProtocol(-1);
+      } else {                         // Logitech spotlight presenter unit got online and USB dongle acknowledged it.
+        // currently it is off as I observed that device send two online packet
+        // one with 0x10 and other with 0x11. Currently initsubDevice is triggered
+        // on 0x11 packet.
+        //connection.initSubDevice();
+      }
     }
   }
 
@@ -348,8 +351,7 @@ void Spotlight::onHIDDataAvailable(int fd, SubHidrawConnection& connection)
       }
     }
 
-    if (readVal.at(2) == 0x04 && readVal.at(4) ==0x01 &&
-            readVal.at(5) == 0x01 && readVal.at(6) == 0x01) {    // Logitech spotlight presenter unit got online.
+    if (readVal.at(2) == 0x04) {    // Logitech spotlight presenter unit got online.
       connection.initSubDevice();
     }
 

--- a/src/spotlight.h
+++ b/src/spotlight.h
@@ -44,6 +44,7 @@ public:
 signals:
   void deviceConnected(const DeviceId& id, const QString& name);
   void deviceDisconnected(const DeviceId& id, const QString& name);
+  void deviceActivated(const DeviceId& id, const QString& name);
   void subDeviceConnected(const DeviceId& id, const QString& name, const QString& path);
   void subDeviceDisconnected(const DeviceId& id, const QString& name, const QString& path);
   void anySpotlightDeviceConnectedChanged(bool connected);


### PR DESCRIPTION
 The software can now read battery information from the device.
Additionally, device details (including battery information is now shown
            in Details tab inside Devices Tab).

This commit shares code with PR #140 .
