### PR TITLE
Fix InputMapper issue with same sized Input Sequences

### DIFF
--- a/src/deviceinput.h
+++ b/src/deviceinput.h
@@ -230,6 +230,8 @@ public:
   void setConfiguration(InputMapConfig&& config);
   const InputMapConfig& configuration() const;
 
+  std::shared_ptr<Action> getAction(KeyEventSequence kes);
+
 signals:
   void configurationChanged();
   void recordingModeChanged(bool recording);


### PR DESCRIPTION
In case, when two different input sequence of same length and same end KeyEvent are defined then InputMapper fails to map to correct action (Please see #144 ).

This PR consisting of two commit fixes the issue with InputMapper.  First commit fixes the issue by deciding the correct action on the basis of all keys pressed (instead of last key pressed in earlier version of code). Second commit refactors `deviceinput.cc` as `struct Next` and `SynKeyEventMap` do not need to save action inside them. 

Fixes #144 