### PR TITLE
Added support for saving FeatureSet in cache file

### DIFF
--- a/src/device.cc
+++ b/src/device.cc
@@ -680,3 +680,9 @@ const HIDPP::FeatureSet* SubHidppConnection::getFeatureSet()
 {
   return &*m_featureSet;
 }
+
+// -------------------------------------------------------------------------------------------------
+QString SubHidppConnection::getFirmwareVersion() const
+{
+  return m_featureSet->getFirmwareVersion();
+}

--- a/src/device.h
+++ b/src/device.h
@@ -200,6 +200,7 @@ public:
   virtual void sendVibrateCommand(uint8_t intensity, uint8_t length);
   virtual void queryBatteryStatus();
   virtual float getHIDppProtocol() const { return -1; };
+  virtual QString getFirmwareVersion() const { return ""; }
 
 signals:
   void flagsChanged(DeviceFlags f);
@@ -278,6 +279,8 @@ public:
   void setHIDppProtocol(float version);
   float getHIDppProtocol() const override { return m_details.HIDppProtocolVer; };
   bool isOnline() const override { return (m_details.HIDppProtocolVer > 0); };
+  QString getFirmwareVersion() const override;
+
 
   void initialize();
 

--- a/src/deviceswidget.cc
+++ b/src/deviceswidget.cc
@@ -181,6 +181,7 @@ void DevicesWidget::updateDeviceDetails(Spotlight* spotlight)
 
     auto sDevices = dc->subDevices();
     bool isOnline = false, hasBattery = false, hasHIDPP = false;
+    QString HIDPPFwVersion;
     float HIDPPversion = -1;
     QStringList HIDPPfeatureText;
     auto HIDppSubDevice = std::find_if(sDevices.cbegin(), sDevices.cend(), [](const auto& sd){
@@ -196,6 +197,7 @@ void DevicesWidget::updateDeviceDetails(Spotlight* spotlight)
       isOnline = dev->isOnline();
       hasBattery = dev->hasFlags(DeviceFlags::ReportBattery);
       HIDPPversion = dev->getHIDppProtocol();
+      HIDPPFwVersion = dev->getFirmwareVersion();
       // report HID++ features recognised by program (like vibration and others)
       HIDPPfeatureText = [dev](){
         QStringList flagList;
@@ -222,11 +224,16 @@ void DevicesWidget::updateDeviceDetails(Spotlight* spotlight)
         }
     };
 
-    deviceDetails += tr("Name:\t\t%1\n").arg(dc->deviceName());
-    deviceDetails += tr("VendorId:\t%1\n").arg(hexId(dc->deviceId().vendorId));
-    deviceDetails += tr("ProductId:\t%1\n").arg(hexId(dc->deviceId().productId));
+
+    auto deviceName = tr("%1 %2(%3:%4)").arg(dc->deviceName())
+            .arg((dc->deviceName().contains(busTypeToString(dc->deviceId().busType)))?
+                     "":tr("(%1) ").arg(busTypeToString(dc->deviceId().busType)))
+            .arg(hexId(dc->deviceId().vendorId))
+            .arg(hexId(dc->deviceId().productId));
+
+    deviceDetails += tr("Device:\t\t%1\n").arg(deviceName);
     deviceDetails += tr("Phys:\t\t%1\n").arg(dc->deviceId().phys);
-    deviceDetails += tr("Bus Type:\t%1\n").arg(busTypeToString(dc->deviceId().busType));
+    if (hasHIDPP && isOnline){ deviceDetails += tr("Firmware:\t%1\n").arg(HIDPPFwVersion); }
     deviceDetails += tr("Sub-Devices:\t%1\n").arg(subDeviceList.join(",\n\t\t"));
     if (hasBattery && isOnline) deviceDetails += tr("Battery Status:\t%1\n").arg(batteryInfoText());
     if (hasHIDPP && !isOnline) deviceDetails += tr("\n\n\t Device not active. Press any key on device to update.\n");

--- a/src/hidpp.h
+++ b/src/hidpp.h
@@ -4,8 +4,7 @@
 #include <map>
 
 #include <QByteArray>
-
-
+#include <QSettings>
 
 // Feature Codes important for Logitech Spotlight
 enum class FeatureCode : uint16_t {
@@ -50,14 +49,17 @@ namespace HIDPP {
   bool isMessageForUsb(const QByteArray& msg);
 
   // Class to get and store Set of supported features for a HID++ 2.0 device
-  class FeatureSet
+  class FeatureSet : public QObject
   {
+    Q_OBJECT
+
   public:
     void setHIDDeviceFileDescriptor(int fd) { m_fdHIDDevice = fd; }
     uint8_t getFeatureIndex(FeatureCode fc) const;
     bool supportFeatureCode(FeatureCode fc) const;
     auto getFeatureCount() const { return m_featureTable.size(); }
     uint8_t getRandomFunctionCode(uint8_t functionCode) const { return (functionCode | m_softwareIDBits); }
+    QString getFirmwareVersion();
     void populateFeatureTable();
 
   private:
@@ -66,9 +68,9 @@ namespace HIDPP {
     QByteArray getFirmwareVersionFromDevice();
     QByteArray getResponseFromDevice(const QByteArray &expectedBytes);
 
+    QByteArray m_firmwareVersion;
     std::map<uint16_t, uint8_t> m_featureTable;
     int m_fdHIDDevice = -1;
     uint8_t m_softwareIDBits = (rand() & 0x0f);
   };
-
 } //end of HIDPP namespace


### PR DESCRIPTION
The HID++ FeatureSet is now saved in a cache file. If the device is
connected again the FeatureSet is loaded from the cache if firmware
version has not changed otherwise HID++ FeatureSet is loaded from
device.

Additionally, Device details tab now show Firmware version also for
HID++ device.
