### PR TITLE
Add button release code for button long press events

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,16 +98,32 @@ line option - button mapping will be disabled then.)
 Input events from the presenter device can be mapped to different actions.
 The _Key Sequence_ action is particularly powerful as it can emit any user-defined
 keystroke. These keystrokes can invoke shortcut in presentation software
-(or any other software) being used.
+(or any other software) being used. Similarly, the _Cycle Preset_ action can be
+used for cycling different spotlight presets. However, it should be noted that
+presets might get reordered after program restart. If user want to maintain the
+order of presets, please prepend the name of preset with number. For example,
+in stead of naming `Pointer` and `Highlight`, name them `1.Pointer` and
+`2.Highlight` to maintain the order.
 
-#### Hold Button Mapping for Logitech Spotlight
+#### Button Mapping for Logitech Spotlight
 
 Logitech Spotlight can send Hold event for Next and Back buttons as HID++
-messages. For mapping those inputs, please ensure that the device is active
-by pressing any button, then go to Input Mapping tab under Devices tab in
-Preferences dialog box and right click in first column (Input Sequence) for
-any entry. Additional mapped actions (e.g. _Vertical Scrolling_ or _Volume control_)
-can be selected for these special hold events.
+messages. Using this device feature, this program provides three different
+usage of the Next or Hold button.
+
+	1. Button Tap
+	2. Long-Press Event (but not longer than Input Sequence Interval
+			setting in Input Mapper tab)
+	3. Button Hold followed by device movement or Hold Move Event
+
+In Input Mapper tab (Devices tab in Preferences dialog box), the first two
+button usage (_i.e._ tap and long-press) can be mapped directly by tapping or
+long pressing the relevant button. For mapping the third button usage (_i.e._
+Hold Move Event), please ensure that the device is active by pressing any button,
+and then right click in first column (Input Sequence) for any entry and select
+the relevant option. Additional mapped actions (e.g. _Vertical Scrolling_,
+_Horizontal Scrolling_, or _Volume control_) can be selected for these hold
+move events.
 
 ## Download
 


### PR DESCRIPTION
This commit add the button release code for signifying the end of
long-press event. While presenting, if a user press next/back button for
a while and then release it within `Input Sequence Interval` time (a
setting in Input Mapper tab), only the action corresponding to
long-press will be executed.

Hence, now there are three specific actions possible for each of Next
and Hold button on Logitech Spotlight:
1. Tap event
2. Long-Press (but not longer than `Input Sequence Interval` setting in Input Mapper tab)
3. Hold Move: It can be mapped to special motion related mapped actions
   like `Scrolling` (Horizontal and Vertical) or `Volume Control`.

The ReadMe is updated accordingly.

![Screenshot from 2021-09-17 22-08-37](https://user-images.githubusercontent.com/578944/133787693-e3760d76-4f07-40b5-a1a3-5f4bfb81d72c.png)