### PR TITLE
Added missing `<array>` include

### DIFF
--- a/src/devicescan.cc
+++ b/src/devicescan.cc
@@ -3,6 +3,8 @@
 
 #include "devicescan.h"
 
+#include <array>
+
 #include <QDirIterator>
 #include <QFileInfo>
 #include <QTextStream>


### PR DESCRIPTION
Forgive me because I don't know much about C++. 😛

I encountered this error whilst building on Arch and was able to fix it by adding an `include` statement:

```
[  2%] Automatic MOC for target projecteur
[  2%] Built target projecteur_autogen
[  5%] Generating qrc_resources.cpp
[  8%] Generating qrc_qml.cpp
[ 11%] Building CXX object CMakeFiles/projecteur.dir/projecteur_autogen/mocs_compilation.cpp.o
[ 13%] Building CXX object CMakeFiles/projecteur.dir/src/main.cc.o
[ 16%] Building CXX object CMakeFiles/projecteur.dir/src/aboutdlg.cc.o
[ 19%] Building CXX object CMakeFiles/projecteur.dir/src/actiondelegate.cc.o
[ 22%] Building CXX object CMakeFiles/projecteur.dir/src/colorselector.cc.o
[ 25%] Building CXX object CMakeFiles/projecteur.dir/src/device.cc.o
[ 27%] Building CXX object CMakeFiles/projecteur.dir/src/device-hidpp.cc.o
[ 30%] Building CXX object CMakeFiles/projecteur.dir/src/device-key-lookup.cc.o
[ 33%] Building CXX object CMakeFiles/projecteur.dir/src/device-vibration.cc.o
[ 36%] Building CXX object CMakeFiles/projecteur.dir/src/deviceinput.cc.o
[ 38%] Building CXX object CMakeFiles/projecteur.dir/src/devicescan.cc.o
/home/sidroberts/Projecteur/src/devicescan.cc:21:40: error: variable ‘const std::array<SupportedDevice, 2> {anonymous}::supportedDefaultDevices’ has initializer but incomplete type
   21 |   const std::array<SupportedDevice, 2> supportedDefaultDevices {{
      |                                        ^~~~~~~~~~~~~~~~~~~~~~~
/home/sidroberts/Projecteur/src/devicescan.cc: In function ‘DeviceScan::Device {anonymous}::deviceFromUEventFile(const QString&)’:
/home/sidroberts/Projecteur/src/devicescan.cc:117:48: error: variable ‘const std::array<const QString*, 3> properties’ has initializer but incomplete type
  117 |     static const std::array<const QString*, 3> properties = {{ &hid_id, &hid_name, &hid_phys }};
      |                                                ^~~~~~~~~~
make[2]: *** [CMakeFiles/projecteur.dir/build.make:242: CMakeFiles/projecteur.dir/src/devicescan.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:144: CMakeFiles/projecteur.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

See also https://github.com/jahnf/Projecteur/issues/181 and https://github.com/jahnf/Projecteur/pull/182