### PR TITLE
Add support for August LP310

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Besides the _Logitech Spotlight_, the following devices are currently supported 
 * AVATTO H100 / August WP200 _(0c45:8101)_
 * August LP315 _(2312:863d)_
 * AVATTO i10 Pro _(2571:4109)_
+* August LP310 _(69a7:9803)_
 
 #### Compile Time
 

--- a/devices.conf
+++ b/devices.conf
@@ -10,3 +10,4 @@
 0x2571, 0x4109, usb, AVATTO i10 Pro
 0x17ef, 0x60d9, usb, Lenovo ThinkPad X1 Presenter Mouse
 0x17ef, 0x60db, bt, Lenovo ThinkPad X1 Presenter Mouse
+0x69a7, 0x9803, usb, August LP310


### PR DESCRIPTION
This PR adds support for the August LP310 device, an inexpensive lower-end presenter with air mouse capabilities. The device works relatively well with Projecteur out of the box (the main issue is that to enable/disable the air mouse, one needs to double-click the laser pointer button, which is annoying).

Note that this was the only reasonably priced device I could find available (and I even found it for a really, really reasonable price). The device can be found for well below 30 EUR (on eBay, there are offerings for less than 40 EUR). Most of the other August/AVATTO devices don't seem to be produced any more, and thus shops don't seem to sell them any more (even though some still list them).

Re. contribution guidelines: since this is a two-line change that won't break anyone's setup, I didn't open an issue first.