### PR TITLE
Basic support for Kensington PowerPointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ Besides the _Logitech Spotlight_, the following devices are currently supported 
 * AVATTO i10 Pro _(2571:4109)_
 * August LP310 _(69a7:9803)_
 * Norwii Wireless Presenter _(3243:0122)_
+* Kensington PowerPointer _(1ea7:0002)_
 
 #### Compile Time
 

--- a/devices.conf
+++ b/devices.conf
@@ -12,3 +12,4 @@
 0x17ef, 0x60db, bt, Lenovo ThinkPad X1 Presenter Mouse
 0x69a7, 0x9803, usb, August LP310
 0x3243, 0x0122, usb, Norwii Wireless Presenter
+0x1ea7, 0x0002, usb, Kensington PowerPointer


### PR DESCRIPTION
Recognize the device; no specific support. See #214 