### PR TITLE
Add Logitech Spotlight 2 Bluetooth support

### DIFF
--- a/55-projecteur.rules.in
+++ b/55-projecteur.rules.in
@@ -15,6 +15,10 @@ SUBSYSTEMS=="input", ENV{LIBINPUT_DEVICE_GROUP}="5/46d/b503*", ATTRS{name}=="SPO
 # Additional rule for Bluetooth sub-devices (hidraw)
 SUBSYSTEMS=="hid", KERNELS=="0005:046D:B503.*", MODE="0660", TAG+="uaccess"
 
+# Rules for the Logitech Spotlight 2 when connected via Bluetooth
+SUBSYSTEM=="input", ATTRS{id/vendor}=="046d", ATTRS{id/product}=="b506", MODE="0660", TAG+="uaccess"
+SUBSYSTEMS=="hid", KERNELS=="0005:046D:B506.*", MODE="0660", TAG+="uaccess"
+
 # Additional supported Bluetooth devices @EXTRA_BLUETOOTH_UDEV_RULES@
 
 # Rules for uinput: Essential for creating a virtual input device that

--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ your screen in an online presentation or call.
 
 Besides the _Logitech Spotlight_, the following devices are currently supported out of the box:
 
+* Logitech Spotlight 2 via Bluetooth _(046d:b506)_
 * AVATTO H100 / August WP200 _(0c45:8101)_
 * August LP315 _(2312:863d)_
 * AVATTO i10 Pro _(2571:4109)_

--- a/src/device-key-lookup.cc
+++ b/src/device-key-lookup.cc
@@ -57,6 +57,7 @@ const QString& lookup(const DeviceId& dId, const DeviceInputEvent& die)
   {
     {dHash({0x046d, 0xc53e}), logitechSpotlightMapping}, // Spotlight USB
     {dHash({0x046d, 0xb503}), logitechSpotlightMapping}, // Spotlight Bluetooth
+    {dHash({0x046d, 0xb506}), logitechSpotlightMapping}, // Spotlight 2 Bluetooth
     {dHash({0x0c45, 0x8101}), avattoH100Mapping},        // Avatto H100, August WP200
   };
 

--- a/src/devicescan.cc
+++ b/src/devicescan.cc
@@ -20,9 +20,10 @@ namespace {
 
   // -----------------------------------------------------------------------------------------------
   // List of supported devices
-  const std::array<SupportedDevice, 2> supportedDefaultDevices {{
+  const std::array<SupportedDevice, 3> supportedDefaultDevices {{
     {0x46d, 0xc53e, false, "Logitech Spotlight (USB)"},
     {0x46d, 0xb503, true, "Logitech Spotlight (Bluetooth)"},
+    {0x46d, 0xb506, true, "Logitech Spotlight 2 (Bluetooth)"},
   }};
 
   // -----------------------------------------------------------------------------------------------

--- a/src/spotlight.cc
+++ b/src/spotlight.cc
@@ -412,7 +412,9 @@ void Spotlight::onEventDataAvailable(int fd, SubEventConnection& connection)
         // relative input event causing the spotlight to be activated.
         // The workaround skips a first input move event from the logitech spotlight device.
         const bool isLogitechSpotlight = connection.deviceId().vendorId == 0x46d
-          && (connection.deviceId().productId == 0xc53e || connection.deviceId().productId == 0xb503);
+          && (connection.deviceId().productId == 0xc53e
+              || connection.deviceId().productId == 0xb503
+              || connection.deviceId().productId == 0xb506);
         const bool logitechIsFirst = isLogitechSpotlight && workaroundLogitechFirstMoveEvent;
 
         if (isLogitechSpotlight)


### PR DESCRIPTION
## Summary

- recognize the Logitech Spotlight 2 Bluetooth device (046d:b506) without requiring -D
- add udev permissions for its input and hidraw interfaces
- reuse the existing Spotlight Click, Next, Back, hold-action, and pointer-motion behavior
- document the new supported device

## Hardware validation

Tested with a connected Logitech Spotlight 2 over Bluetooth:

- Qt 5 build succeeds
- generated udev rules pass udevadm verify
- projecteur --device-scan finds all three interfaces as readable and writable
- HID++ protocol 4.5 negotiation succeeds
- Reset, ReprogramControlsV4, and PointerSpeed initialize successfully
- the device does not advertise the legacy BatteryStatus or PresenterControl vibration features, so those optional capabilities remain disabled
- disconnect/reconnect discovery works through the existing Bluetooth scan path